### PR TITLE
Fix names of example UDCs to match real UDCs

### DIFF
--- a/earthly/cspell/Readme.md
+++ b/earthly/cspell/Readme.md
@@ -34,7 +34,7 @@ spellcheck-lint:
     # Check spelling in this repo.
     LOCALLY
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/cspell:t1.2.0+CSPELL --src=$(echo ${PWD})
+    DO github.com/input-output-hk/catalyst-ci/earthly/cspell:t1.2.0+CSPELL_LOCALLY --src=$(echo ${PWD})
 ```
 
 In this use case, the UDC is run Locally, so that the src in the repo can be directly checked.

--- a/earthly/mdlint/Readme.md
+++ b/earthly/mdlint/Readme.md
@@ -29,13 +29,13 @@ markdown-lint:
     # Check Markdown in this repo.
     LOCALLY
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/mdlint:v1.2.0+MDLINT --src=$(echo ${PWD})
+    DO github.com/input-output-hk/catalyst-ci/earthly/mdlint:v1.2.0+MDLINT_LOCALLY --src=$(echo ${PWD})
 
 markdown-lint-fix:
     # Check Markdown in this repo.
     LOCALLY
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/mdlint:v1.2.0+MDLINT --src=$(echo ${PWD}) --fix=--fix
+    DO github.com/input-output-hk/catalyst-ci/earthly/mdlint:v1.2.0+MDLINT_LOCALLY --src=$(echo ${PWD}) --fix=--fix
 ```
 
 In this use case, the UDC is run Locally, so that the markdown in the repo can be directly checked.


### PR DESCRIPTION
Correct documentation for `mdlint` and `cspell` UDCs to use the correct UDC name.