### PR TITLE
chore: cleans up actions

### DIFF
--- a/actions/discover/dist/index.js
+++ b/actions/discover/dist/index.js
@@ -3155,9 +3155,7 @@ async function run() {
         if (targets.trim() !== '') {
             flags.push(...targets.split(' ').map(t => `-t ${t}`));
         }
-        const command = ['ci', 'scan', ...flags, paths]
-            .filter(Boolean)
-            .join(' ');
+        const command = ['ci', 'scan', ...flags, paths].filter(Boolean).join(' ');
         core.info(`Running command: ${command}`);
         core.setOutput('json', await execCommand(command));
     }
@@ -3182,7 +3180,6 @@ async function execCommand(command) {
         });
     });
 }
-run();
 
 ;// CONCATENATED MODULE: ./src/index.ts
 

--- a/actions/discover/src/discover.test.ts
+++ b/actions/discover/src/discover.test.ts
@@ -2,8 +2,6 @@ import * as core from '@actions/core'
 import { exec } from 'child_process'
 import { run } from './discover'
 
-// cspell: words omashu
-
 jest.mock('@actions/core', () => ({
   getBooleanInput: jest.fn(),
   getInput: jest.fn(),
@@ -49,12 +47,13 @@ describe('Discover Action', () => {
       }
     ]
 
-    it.each(testCases)(
-      'should execute the correct command for parseImages=%s, paths=%s, targets=%s',
-      async ({ parseImages, paths, targets, expectedCommand }) => {
-        const getBooleanInputMock = core.getBooleanInput as jest.Mock
-        const getInputMock = core.getInput as jest.Mock
+    // actions mocks
+    const getBooleanInputMock = core.getBooleanInput as jest.Mock
+    const getInputMock = core.getInput as jest.Mock
 
+    it.each(testCases)(
+      'should execute the correct command',
+      async ({ parseImages, paths, targets, expectedCommand }) => {
         getBooleanInputMock.mockReturnValue(parseImages)
         getInputMock.mockImplementation((name: string) => {
           switch (name) {
@@ -70,10 +69,7 @@ describe('Discover Action', () => {
         await run()
 
         expect(exec).toHaveBeenCalledWith(expectedCommand, expect.anything())
-        expect(core.setOutput as jest.Mock).toHaveBeenCalledWith(
-          'json',
-          'mocked output'
-        )
+        expect(core.setOutput).toHaveBeenCalledWith('json', 'mocked output')
       }
     )
   })

--- a/actions/discover/src/discover.ts
+++ b/actions/discover/src/discover.ts
@@ -36,5 +36,3 @@ async function execCommand(command: string): Promise<string> {
     })
   })
 }
-
-run()


### PR DESCRIPTION
- fix: don't run discover action twice
- chore: cleanup discover action test
- chore: package
