### PR TITLE
Updated aarch64-unknown-linux-gnu rustflags, updated rust Earthly targets

### DIFF
--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -52,20 +52,9 @@ rustup:
 # Common Rust setup
 # Parameters:
 #  * toolchain : The `rust-toolchain` toml file.
-#  * with_cargo_nextest: <true/false> Flag to install cargo-nextest tool
-#  * with_cargo_chef: <true/false> Flag to install cargo-chef tool
-#  * with_kani: <true/false> Flag to install kani-verifier and kani tools
-#  * with_refinery: <true/false> Flag to install refinery tool
-#  * with_cargo_machete: <true/false> Flag to install cargo-machete tool
 RUST_SETUP:
     COMMAND
     ARG toolchain=./rust-toolchain.toml
-
-    ARG with_cargo_nextest=false
-    ARG with_cargo_chef=false
-    ARG with_kani=false
-    ARG with_refinery=false
-    ARG with_cargo_machete=false
 
     # Poetry Installation directory.
     # Gives poetry and our poetry project a reliable location.
@@ -84,40 +73,15 @@ RUST_SETUP:
         cargo +nightly --version
 
     # Install tools we use commonly with `cargo`.
-    IF [ "$with_cargo_nextest" = "true" ]
-        RUN cargo install cargo-nextest --locked
-    END
-    IF [ "$with_cargo_chef" = "true" ]
-        RUN cargo install cargo-chef --locked
-    END
-    IF [ "$with_kani" = "true" ]
-        RUN cargo install kani-verifier --locked && \
-        cargo kani setup
-    END
-    IF [ "$with_refinery" = "true" ]
-        RUN cargo install refinery_cli --locked
-    END
-    IF [ "$with_cargo_machete" = "true" ]
-        RUN cargo install cargo-machete --locked
-    END
+    RUN cargo install cargo-nextest --locked && \
+        cargo install refinery_cli --locked && \
+        cargo install cargo-machete --locked
 
 # Test rust build container
 check:
     FROM +rustup
 
-    ARG with_cargo_nextest=true
-    ARG with_cargo_chef=true
-    ARG with_kani=true
-    ARG with_refinery=true
-    ARG with_cargo_machete=true
-
-    DO +RUST_SETUP \
-        --toolchain=example/rust-toolchain.toml \
-        --with_cargo_nextest="$with_cargo_nextest" \
-        --with_cargo_chef="$with_cargo_chef" \
-        --with_kani="$with_kani" \
-        --with_refinery="$with_refinery" \
-        --with_cargo_machete="$with_cargo_machete"
+    DO +RUST_SETUP --toolchain=example/rust-toolchain.toml
 
     # Check all the expected tooling is installed and works for both the stable and nightly versions.
     RUN rustc --version && \
@@ -126,20 +90,7 @@ check:
         cargo +nightly --version &&  \
         cargo clippy --version && \
         cargo +nightly clippy --version && \
+        cargo nextest --version && \
+        cargo machete --version \
         refinery --version && \
         mold --version
-    IF [ "$with_cargo_nextest" = "true" ]
-        RUN cargo nextest --version
-    END
-    IF [ "$with_cargo_chef" = "true" ]
-        RUN cargo chef --version
-    END
-    IF [ "$with_kani" = "true" ]
-        RUN cargo kani --version
-    END
-    IF [ "$with_refinery" = "true" ]
-        RUN refinery --version
-    END
-    IF [ "$with_cargo_machete" = "true" ]
-        RUN cargo machete --version
-    END

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -52,9 +52,20 @@ rustup:
 # Common Rust setup
 # Parameters:
 #  * toolchain : The `rust-toolchain` toml file.
+#  * with_cargo_nextest: <true/false> Flag to install cargo-nextest tool
+#  * with_cargo_chef: <true/false> Flag to install cargo-chef tool
+#  * with_kani: <true/false> Flag to install kani-verifier and kani tools
+#  * with_refinery: <true/false> Flag to install refinery tool
+#  * with_cargo_machete: <true/false> Flag to install cargo-machete tool
 RUST_SETUP:
     COMMAND
     ARG toolchain=./rust-toolchain.toml
+
+    ARG with_cargo_nextest=false
+    ARG with_cargo_chef=false
+    ARG with_kani=false
+    ARG with_refinery=false
+    ARG with_cargo_machete=false
 
     # Poetry Installation directory.
     # Gives poetry and our poetry project a reliable location.
@@ -73,18 +84,40 @@ RUST_SETUP:
         cargo +nightly --version
 
     # Install tools we use commonly with `cargo`.
-    RUN cargo install cargo-nextest --locked && \
-        cargo install cargo-chef --locked && \
-        cargo install kani-verifier --locked && \
-        cargo kani setup && \
-        cargo install refinery_cli --locked && \
-        cargo install cargo-machete --locked
+    IF [ "$with_cargo_nextest" = "true" ]
+        RUN cargo install cargo-nextest --locked
+    END
+    IF [ "$with_cargo_chef" = "true" ]
+        RUN cargo install cargo-chef --locked
+    END
+    IF [ "$with_kani" = "true" ]
+        RUN cargo install kani-verifier --locked && \
+        cargo kani setup
+    END
+    IF [ "$with_refinery" = "true" ]
+        RUN cargo install refinery_cli --locked
+    END
+    IF [ "$with_cargo_machete" = "true" ]
+        RUN cargo install cargo-machete --locked
+    END
 
 # Test rust build container
 check:
     FROM +rustup
 
-    DO +RUST_SETUP --toolchain=example/rust-toolchain.toml
+    ARG with_cargo_nextest=true
+    ARG with_cargo_chef=true
+    ARG with_kani=true
+    ARG with_refinery=true
+    ARG with_cargo_machete=true
+
+    DO +RUST_SETUP \
+        --toolchain=example/rust-toolchain.toml \
+        --with_cargo_nextest="$with_cargo_nextest" \
+        --with_cargo_chef="$with_cargo_chef" \
+        --with_kani="$with_kani" \
+        --with_refinery="$with_refinery" \
+        --with_cargo_machete="$with_cargo_machete"
 
     # Check all the expected tooling is installed and works for both the stable and nightly versions.
     RUN rustc --version && \
@@ -93,11 +126,20 @@ check:
         cargo +nightly --version &&  \
         cargo clippy --version && \
         cargo +nightly clippy --version && \
-        cargo nextest --version && \
-        cargo chef --version && \
-        cargo kani --version && \
         refinery --version && \
         mold --version
-
-
-
+    IF [ "$with_cargo_nextest" = "true" ]
+        RUN cargo nextest --version
+    END
+    IF [ "$with_cargo_chef" = "true" ]
+        RUN cargo chef --version
+    END
+    IF [ "$with_kani" = "true" ]
+        RUN cargo kani --version
+    END
+    IF [ "$with_refinery" = "true" ]
+        RUN refinery --version
+    END
+    IF [ "$with_cargo_machete" = "true" ]
+        RUN cargo machete --version
+    END

--- a/earthly/rust/config.toml
+++ b/earthly/rust/config.toml
@@ -13,14 +13,14 @@ rustflags = [
 linker = "clang"
 rustflags = [
     "-C", "link-arg=-fuse-ld=/usr/bin/mold",
-    # "-C", "target-feature=+crt-static" - Doesn't work for nextest.
+    # "-C", "target-feature=+crt-static" - proc-macro doesn't work with it. `https://github.com/rust-lang/rust/issues/78210`
 ]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "clang"
 rustflags = [
     "-C", "link-arg=-fuse-ld=/usr/bin/mold",
-    "-C", "target-feature=+crt-static"
+    # "-C", "target-feature=+crt-static" - proc-macro doesn't work with it. `https://github.com/rust-lang/rust/issues/78210`
 ]
 
 [target.aarch64-unknown-linux-musl]


### PR DESCRIPTION
Close https://github.com/input-output-hk/catalyst-ci/issues/53

- fixed aarch64-unknown-linux-gnu rustflags, to solve an issue with cargo-nextest build, disable `target-feature=+crt-static` flag
- updated rust Earthly targets, added `with_cargo_nextest`, `with_cargo_chef`, `with_kani`, `with_refinery` and `with_cargo_machete` earthly arguuments, so it is possible to conditionally install these tools.
- fixed following issues on the `aarch64-unknown-linux-gnu` when eathly rust targets are runned on the macOS M1:
```
cannot produce proc-macro for `async-trait v0.1.74` as the target `aarch64-unknown-linux-gnu` does not support these crate types
```
```
Error: Kani does not support this platform (Rust target aarch64-unknown-linux-gnu)
```