### PR TITLE
feat: Add integration tests for PostgreSQL builder

### DIFF
--- a/earthly/postgresql/Earthfile
+++ b/earthly/postgresql/Earthfile
@@ -143,8 +143,35 @@ test-3:
             assert_eq "$expected" "$res"
     END
 
+# PostgreSQL server runs as a separate service, drops and initialises db, applies migrations, applies seed data.
+test-4:
+    FROM +postgres-base
+
+    COPY ../utils+shell-assert/assert.sh .
+
+    ENV DB_HOST postgres
+    ENV INIT_AND_DROP_DB true
+    ENV WITH_MIGRATIONS true
+    ENV WITH_SEED_DATA true
+    COPY ./example/docker-compose.yml .
+    WITH DOCKER \
+        --compose docker-compose.yml \
+        --pull postgres:16 \
+        --load example-db:latest=+build \
+        --service example \
+        --service postgres \
+        --allow-privileged
+        RUN sleep 5;\
+            res=$(psql postgresql://postgres:postgres@0.0.0.0:5433/ExampleDb -c "SELECT * FROM users");\
+            
+            source assert.sh;\
+            expected=$(printf "  name   | age \n---------+-----\n Alice   |  20\n Bob     |  30\n Charlie |  40\n(3 rows)");\
+            assert_eq "$expected" "$res"
+    END
+
 # Invoke all tests
 test:
     BUILD +test-1
     BUILD +test-2
     BUILD +test-3
+    BUILD +test-4

--- a/earthly/postgresql/Earthfile
+++ b/earthly/postgresql/Earthfile
@@ -1,7 +1,7 @@
 # Common PostgreSQL Earthly builders
 VERSION 0.7
 
-# cspell: words colordiff rustup rustc
+# cspell: words colordiff rustup rustc psql
 
 postgres-base:
     FROM postgres:16.0-alpine3.18
@@ -80,7 +80,7 @@ build:
 
     DO +BUILD --image_name=example-db
 
-# Container runs PostgreSQL server, drops and initialises db, applies migrations, applies seed data.
+# Container runs PostgreSQL server, drops and initialise db, applies migrations, applies seed data.
 test-1:
     FROM +postgres-base
 
@@ -103,7 +103,7 @@ test-1:
             assert_eq "$expected" "$res"
     END
 
-# Container runs PostgreSQL server, drops and initialises db, doesn't apply migrations, doesn't apply seed data.
+# Container runs PostgreSQL server, drops and initialise db, doesn't apply migrations, doesn't apply seed data.
 test-2:
     FROM +postgres-base
 
@@ -120,7 +120,7 @@ test-2:
             ! psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users"
     END
 
-# Container runs PostgreSQL server, drops and initialises db, applies migrations, doesn't apply seed data.
+# Container runs PostgreSQL server, drops and initialise db, applies migrations, doesn't apply seed data.
 test-3:
     FROM +postgres-base
 
@@ -143,7 +143,7 @@ test-3:
             assert_eq "$expected" "$res"
     END
 
-# PostgreSQL server runs as a separate service, drops and initialises db, applies migrations, applies seed data.
+# PostgreSQL server runs as a separate service, drops and initialise db, applies migrations, applies seed data.
 test-4:
     FROM +postgres-base
 

--- a/earthly/postgresql/Earthfile
+++ b/earthly/postgresql/Earthfile
@@ -130,3 +130,9 @@ test-3:
         RUN sleep 5;\
             psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users"
     END
+
+# Invoke all tests
+test:
+    BUILD +test-1
+    BUILD +test-2
+    BUILD +test-3

--- a/earthly/postgresql/Earthfile
+++ b/earthly/postgresql/Earthfile
@@ -79,3 +79,17 @@ build:
     FROM +builder
 
     DO +BUILD --image_name=example-db
+
+# Container runs PostgreSQL server, drops and initialises db, applies migrations, applies seed data.
+test-1:
+    FROM +postgres-base
+
+    COPY ./example/docker-compose.yml .
+    WITH DOCKER \
+        --compose docker-compose.yml \
+        --load example-db:latest=+build \
+        --service example \
+        --allow-privileged
+        RUN sleep 5;\
+            psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users"
+    END

--- a/earthly/postgresql/Earthfile
+++ b/earthly/postgresql/Earthfile
@@ -84,6 +84,8 @@ build:
 test-1:
     FROM +postgres-base
 
+    COPY ../utils+shell-assert/assert.sh .
+
     ENV INIT_AND_DROP_DB true
     ENV WITH_MIGRATIONS true
     ENV WITH_SEED_DATA true
@@ -94,7 +96,11 @@ test-1:
         --service example \
         --allow-privileged
         RUN sleep 5;\
-            psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users"
+            res=$(psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users");\
+            
+            source assert.sh;\
+            expected=$(printf "  name   | age \n---------+-----\n Alice   |  20\n Bob     |  30\n Charlie |  40\n(3 rows)");\
+            assert_eq "$expected" "$res"
     END
 
 # Container runs PostgreSQL server, drops and initialises db, doesn't apply migrations, doesn't apply seed data.
@@ -118,6 +124,8 @@ test-2:
 test-3:
     FROM +postgres-base
 
+    COPY ../utils+shell-assert/assert.sh .
+
     ENV INIT_AND_DROP_DB true
     ENV WITH_MIGRATIONS true
     ENV WITH_SEED_DATA false
@@ -128,7 +136,11 @@ test-3:
         --service example \
         --allow-privileged
         RUN sleep 5;\
-            psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users"
+            res=$(psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users");\
+
+            source assert.sh;\
+            expected=$(printf " name | age \n------+-----\n(0 rows)");\
+            assert_eq "$expected" "$res"
     END
 
 # Invoke all tests

--- a/earthly/postgresql/Earthfile
+++ b/earthly/postgresql/Earthfile
@@ -84,6 +84,9 @@ build:
 test-1:
     FROM +postgres-base
 
+    ENV INIT_AND_DROP_DB true
+    ENV WITH_MIGRATIONS true
+    ENV WITH_SEED_DATA true
     COPY ./example/docker-compose.yml .
     WITH DOCKER \
         --compose docker-compose.yml \
@@ -91,5 +94,6 @@ test-1:
         --service example \
         --allow-privileged
         RUN sleep 5;\
+            docker-compose logs example;\
             psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users"
     END

--- a/earthly/postgresql/Earthfile
+++ b/earthly/postgresql/Earthfile
@@ -94,6 +94,39 @@ test-1:
         --service example \
         --allow-privileged
         RUN sleep 5;\
-            docker-compose logs example;\
+            psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users"
+    END
+
+# Container runs PostgreSQL server, drops and initialises db, doesn't apply migrations, doesn't apply seed data.
+test-2:
+    FROM +postgres-base
+
+    ENV INIT_AND_DROP_DB true
+    ENV WITH_MIGRATIONS false
+    ENV WITH_SEED_DATA false
+    COPY ./example/docker-compose.yml .
+    WITH DOCKER \
+        --compose docker-compose.yml \
+        --load example-db:latest=+build \
+        --service example \
+        --allow-privileged
+        RUN sleep 5;\
+            ! psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users"
+    END
+
+# Container runs PostgreSQL server, drops and initialises db, applies migrations, doesn't apply seed data.
+test-3:
+    FROM +postgres-base
+
+    ENV INIT_AND_DROP_DB true
+    ENV WITH_MIGRATIONS true
+    ENV WITH_SEED_DATA false
+    COPY ./example/docker-compose.yml .
+    WITH DOCKER \
+        --compose docker-compose.yml \
+        --load example-db:latest=+build \
+        --service example \
+        --allow-privileged
+        RUN sleep 5;\
             psql postgresql://example-dev:example-pass@0.0.0.0:5432/ExampleDb -c "SELECT * FROM users"
     END

--- a/earthly/postgresql/entry.sh
+++ b/earthly/postgresql/entry.sh
@@ -69,18 +69,6 @@ REQUIRED_ENV=(
 )
 check_env_vars "${REQUIRED_ENV[@]}"
 
-# Export environment variables
-export PGHOST="${DB_HOST}"
-export PGPORT="${DB_PORT}"
-export PGUSER="${DB_SUPERUSER}"
-export PGPASSWORD="${DB_SUPERUSER_PASSWORD}"
-export PGDATABASE="${DB_NAME}"
-
-: "${ADMIN_FIRST_NAME:='Admin'}"
-: "${ADMIN_LAST_NAME:='Default'}"
-: "${ADMIN_ABOUT:='Default Admin User'}"
-: "${ADMIN_EMAIL:='admin.default@projectcatalyst.io'}"
-
 # Sleep if DEBUG_SLEEP is set
 debug_sleep
 

--- a/earthly/postgresql/entry.sh
+++ b/earthly/postgresql/entry.sh
@@ -86,10 +86,7 @@ debug_sleep
 
 # Run postgreSQL database in this container if the host is localhost
 if [ "${DB_HOST}" == "localhost" ]; then
-    # Set the timeout value in seconds (default: 0 = wait forever)
-    TIMEOUT=${TIMEOUT:-0}
     POSTGRES_HOST_AUTH_METHOD=${POSTGRES_HOST_AUTH_METHOD:-trust}
-    echo "TIMEOUT is set to ${TIMEOUT}"
     echo "POSTGRES_HOST_AUTH_METHOD is set to ${POSTGRES_HOST_AUTH_METHOD}"
 
     # Start PostgreSQL in the background
@@ -100,6 +97,9 @@ fi
 
 # Check if PostgreSQL is running using psql
 echo "Waiting for PostgreSQL to start..."
+# Set the timeout value in seconds (default: 0 = wait forever)
+TIMEOUT=${TIMEOUT:-0}
+echo "TIMEOUT is set to ${TIMEOUT}"
 until pg_isready -h $DB_HOST -p $DB_PORT -U $DB_SUPERUSER -d postgres >/dev/null 2>&1; do
     sleep 1
     if [ $TIMEOUT -gt 0 ]; then

--- a/earthly/postgresql/entry.sh
+++ b/earthly/postgresql/entry.sh
@@ -128,7 +128,7 @@ if [ "${WITH_SEED_DATA:-}" == "true" ]; then
     echo ">>> Applying seed data..."
     while IFS= read -r -d '' file; do
         echo "Applying seed data from $file"
-        psql -d $DB_NAME -U $DB_USER -W $DB_USER_PASSWORD -f "$file"
+        psql -d $DB_NAME -f "$file"
     done < <(find ./data -name '*.sql' -print0 | sort -z)
 fi
 

--- a/earthly/postgresql/example/docker-compose.yml
+++ b/earthly/postgresql/example/docker-compose.yml
@@ -1,5 +1,7 @@
 version: "3"
 
+# cspell: words healthcheck isready
+
 services:
   postgres:
     image: postgres:16

--- a/earthly/postgresql/example/docker-compose.yml
+++ b/earthly/postgresql/example/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       - DB_USER=example-dev
       - DB_USER_PASSWORD=example-pass
 
-      - INIT_AND_DROP_DB=true
-      - WITH_MIGRATIONS=true
-      - WITH_SEED_DATA=true
+      - INIT_AND_DROP_DB=${INIT_AND_DROP_DB:-true}
+      - WITH_MIGRATIONS=${WITH_MIGRATIONS:-true}
+      - WITH_SEED_DATA=${WITH_SEED_DATA:-true}
     ports:
       - 5432:5432

--- a/earthly/postgresql/example/docker-compose.yml
+++ b/earthly/postgresql/example/docker-compose.yml
@@ -1,11 +1,26 @@
 version: "3"
 
 services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+    ports:
+      - 5433:5432
+
   example:
     image: example-db:latest
     environment:
       # Required environment variables for migrations
-      - DB_HOST=localhost
+      - DB_HOST=${DB_HOST:-localhost}
       - DB_PORT=5432
       - DB_NAME=ExampleDb
       - DB_DESCRIPTION="Example DB"

--- a/earthly/utils/Earthfile
+++ b/earthly/utils/Earthfile
@@ -1,0 +1,10 @@
+# Common PostgreSQL Earthly builders
+VERSION 0.7
+
+shell-assert:
+    FROM scratch
+
+    WORKDIR /assert-sh
+
+    COPY assert.sh .
+    SAVE ARTIFACT assert.sh assert.sh

--- a/earthly/utils/README.md
+++ b/earthly/utils/README.md
@@ -1,0 +1,3 @@
+# Earthly Utils
+
+This directory contains utility Earthly targets and tools for working with Earthly.

--- a/earthly/utils/assert.sh
+++ b/earthly/utils/assert.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+
+  if [ "$expected" == "$actual" ]; then
+    return 0
+  else
+    echo "assert_eq FAILED"
+    echo "expected:"
+    echo "$expected"
+    echo "actual:"
+    echo "$actual"
+    echo "Diff:"
+    diff  <(echo "$expected" ) <(echo "$actual")
+    return 1
+  fi
+}


### PR DESCRIPTION
Close #67

- Added 4 test cases of the integration tests for the PostgreSQL builder
- Cleanup entry.sh script
- Added utils dir for the Earthly utility stuff, added assert bash scripts, which are used to validate returned data from the db in Earthly targets