### PR TITLE
fix: Add -P flag for earhtly `test` CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
       ci_cli_version: ${{ inputs.ci_cli_version }}
       earthly_version: ${{ inputs.earthly_version }}
       target: test
+      privileged: true
     secrets:
       dockerhub_token: ${{ secrets.dockerhub_token }}
       dockerhub_username: ${{ secrets.dockerhub_username }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -106,7 +106,7 @@ jobs:
           earthly_version: ${{ inputs.earthly_version }}
           earthly_runner_secret: ${{ secrets.earthly_runner_secret }}
       - name: Run
-        uses: input-output-hk/catalyst-ci/actions/run@fix/ci-run
+        uses: input-output-hk/catalyst-ci/actions/run@master
         id: build
         with:
           privileged: ${{ inputs.privileged }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -106,7 +106,7 @@ jobs:
           earthly_version: ${{ inputs.earthly_version }}
           earthly_runner_secret: ${{ secrets.earthly_runner_secret }}
       - name: Run
-        uses: input-output-hk/catalyst-ci/actions/run@master
+        uses: input-output-hk/catalyst-ci/actions/run@fix/ci-run
         id: build
         with:
           privileged: ${{ inputs.privileged }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -3,6 +3,12 @@
 on:
     workflow_call:
       inputs:
+        privileged:
+          description: |
+            Whether the workflow should run earthly in privileged mode (earthly -P flag).
+          required: false
+          type: boolean
+          default: false
         target:
           description: |
             The target to run.
@@ -103,6 +109,7 @@ jobs:
         uses: input-output-hk/catalyst-ci/actions/run@master
         id: build
         with:
+          privileged: ${{ inputs.privileged }}
           earthfile: ${{ matrix.earthfile }}
           target: ${{ inputs.target }}
           runner_address: ${{ secrets.earthly_runner_address }}

--- a/actions/run/action.yml
+++ b/actions/run/action.yml
@@ -18,6 +18,10 @@ inputs:
   platform:
     description: The platform to execute the earthfile target with (defaults to native)
     required: false
+  privileged:
+    description: Whether the workflow should run earthly in privileged mode (earthly -P flag).
+    required: false
+    default: "false"
   runner_address:
     description: The address of the remote runner to use
     required: false

--- a/actions/run/dist/index.js
+++ b/actions/run/dist/index.js
@@ -2882,12 +2882,16 @@ async function run() {
     const earthfile = core.getInput('earthfile');
     const flags = core.getInput('flags');
     const platform = core.getInput('platform');
+    const privileged = core.getBooleanInput('privileged');
     const runnerAddress = core.getInput('runner_address');
     const runnerPort = core.getInput('runner_port');
     const target = core.getInput('target');
     const targetFlags = core.getInput('target_flags');
     const command = 'earthly';
     const args = [];
+    if (privileged) {
+        args.push('-P');
+    }
     if (runnerAddress) {
         args.push('--buildkit-host', `tcp://${runnerAddress}:${runnerPort}`);
     }

--- a/actions/run/src/run.test.ts
+++ b/actions/run/src/run.test.ts
@@ -27,6 +27,7 @@ describe('Run Action', () => {
         earthfile: './earthfile',
         flags: '',
         platform: '',
+        privileged: '',
         output: '',
         runnerAddress: '',
         runnerPort: '',
@@ -42,6 +43,7 @@ describe('Run Action', () => {
         earthfile: './earthfile',
         flags: '--test',
         platform: '',
+        privileged: '',
         output: 'Artifact +target/artifact output as out\n',
         runnerAddress: '',
         runnerPort: '',
@@ -57,6 +59,7 @@ describe('Run Action', () => {
         earthfile: './earthfile',
         flags: '',
         platform: '',
+        privileged: '',
         output: '',
         runnerAddress: 'localhost',
         runnerPort: '8372',
@@ -76,12 +79,14 @@ describe('Run Action', () => {
         earthfile: './earthfile',
         flags: '--flag1 test -f2 test2',
         platform: 'linux/amd64',
+        privileged: 'true',
         output: 'Image +docker output as image1:tag1\n',
         runnerAddress: '',
         runnerPort: '',
         target: 'target',
         targetFlags: '',
         command: [
+          '-P',
           '--platform',
           'linux/amd64',
           '--flag1',
@@ -101,6 +106,7 @@ describe('Run Action', () => {
         earthfile,
         flags,
         platform,
+        privileged,
         output,
         runnerAddress,
         runnerPort,
@@ -122,6 +128,8 @@ describe('Run Action', () => {
               return flags
             case 'platform':
               return platform
+            case 'privileged':
+              return privileged
             case 'output':
               return output
             case 'runner_address':
@@ -141,6 +149,8 @@ describe('Run Action', () => {
           switch (name) {
             case 'artifact':
               return artifact === 'true'
+            case 'privileged':
+              return privileged === 'true'
             default:
               throw new Error('Unknown input')
           }

--- a/actions/run/src/run.ts
+++ b/actions/run/src/run.ts
@@ -16,6 +16,9 @@ export async function run(): Promise<void> {
   const command = 'earthly'
   const args: string[] = []
 
+  args.push('-P')
+  core.info(`args: ${args.join(' ')}`)
+
   if (runnerAddress) {
     args.push('--buildkit-host', `tcp://${runnerAddress}:${runnerPort}`)
   }
@@ -23,8 +26,6 @@ export async function run(): Promise<void> {
   if (platform) {
     args.push('--platform', platform)
   }
-
-  args.push('-P')
 
   if (flags) {
     args.push(...flags.split(' '))

--- a/actions/run/src/run.ts
+++ b/actions/run/src/run.ts
@@ -17,7 +17,6 @@ export async function run(): Promise<void> {
   const args: string[] = []
 
   args.push('-P')
-  core.info(`args: ${args.join(' ')}`)
 
   if (runnerAddress) {
     args.push('--buildkit-host', `tcp://${runnerAddress}:${runnerPort}`)

--- a/actions/run/src/run.ts
+++ b/actions/run/src/run.ts
@@ -8,6 +8,7 @@ export async function run(): Promise<void> {
   const earthfile = core.getInput('earthfile')
   const flags = core.getInput('flags')
   const platform = core.getInput('platform')
+  const privileged = core.getBooleanInput('privileged')
   const runnerAddress = core.getInput('runner_address')
   const runnerPort = core.getInput('runner_port')
   const target = core.getInput('target')
@@ -16,7 +17,9 @@ export async function run(): Promise<void> {
   const command = 'earthly'
   const args: string[] = []
 
-  args.push('-P')
+  if (privileged) {
+    args.push('-P')
+  }
 
   if (runnerAddress) {
     args.push('--buildkit-host', `tcp://${runnerAddress}:${runnerPort}`)

--- a/actions/run/src/run.ts
+++ b/actions/run/src/run.ts
@@ -24,6 +24,8 @@ export async function run(): Promise<void> {
     args.push('--platform', platform)
   }
 
+  args.push('-P')
+
   if (flags) {
     args.push(...flags.split(' '))
   }


### PR DESCRIPTION
It is needed to pass `-P` flag to earthly during tests running to fix the following issue https://github.com/input-output-hk/catalyst-ci/actions/runs/6733556300/job/18302659923