### PR TITLE
feat: Add SQLFluff sql linter to PostgreSQL builder

### DIFF
--- a/earthly/postgresql/.sqlfluff
+++ b/earthly/postgresql/.sqlfluff
@@ -1,0 +1,8 @@
+[sqlfluff]
+dialect = postgres
+
+[sqlfluff:indentation]
+tab_space_size = 2
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = upper

--- a/earthly/postgresql/.sqlfluff
+++ b/earthly/postgresql/.sqlfluff
@@ -1,5 +1,6 @@
 [sqlfluff]
 dialect = postgres
+large_file_skip_char_limit = 0
 
 [sqlfluff:indentation]
 tab_space_size = 2

--- a/earthly/postgresql/.sqlfluff
+++ b/earthly/postgresql/.sqlfluff
@@ -6,3 +6,11 @@ tab_space_size = 2
 
 [sqlfluff:rules:capitalisation.keywords]
 capitalisation_policy = upper
+[sqlfluff:rules:capitalisation.identifiers]
+extended_capitalisation_policy = lower
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = upper
+[sqlfluff:rules:capitalisation.literals]
+extended_capitalisation_policy = upper
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = upper

--- a/earthly/postgresql/Earthfile
+++ b/earthly/postgresql/Earthfile
@@ -17,16 +17,11 @@ postgres-base:
             musl-dev \
             curl \
             gcc \
-            py3-pip
-
-    # Install SQLFluff
-    RUN pip3 install sqlfluff
-    RUN sqlfluff version
+            python3
 
     # Get refinery
     COPY ../rust+rust-base/refinery /bin
 
-    COPY ./.sqlfluff .
     COPY ./entry.sh .
     COPY ./setup-db.sql .
 
@@ -44,7 +39,19 @@ BUILDER:
 CHECK:
     COMMAND
 
-    RUN sqlfluff lint .
+    # Where we want to run the `lint` from.
+    ARG --required src
+
+    RUN docker run --rm -v $src:/sql sqlfluff/sqlfluff:latest lint .
+
+# Format sql files
+FORMAT:
+    COMMAND
+
+    # Where we want to run the `lint` from.
+    ARG --required src
+
+    RUN docker run --rm -v $src:/sql sqlfluff/sqlfluff:latest format .
 
 
 # Build PostgreSQL image.
@@ -79,9 +86,14 @@ builder:
     DO +BUILDER
 
 check:
-    FROM +builder
+    LOCALLY
 
-    DO +CHECK
+    DO +CHECK --src=$(echo ${PWD})
+
+format:
+    LOCALLY
+
+    DO +FORMAT --src=$(echo ${PWD})
 
 build:
     FROM +builder

--- a/earthly/postgresql/Earthfile
+++ b/earthly/postgresql/Earthfile
@@ -17,11 +17,16 @@ postgres-base:
             musl-dev \
             curl \
             gcc \
-            python3
+            py3-pip
+
+    # Install SQLFluff
+    RUN pip3 install sqlfluff
+    RUN sqlfluff version
 
     # Get refinery
     COPY ../rust+rust-base/refinery /bin
 
+    COPY ./.sqlfluff .
     COPY ./entry.sh .
     COPY ./setup-db.sql .
 
@@ -30,14 +35,17 @@ postgres-base:
 BUILDER:
     COMMAND
 
+    RUN cp /root/.sqlfluff .
     RUN cp /root/entry.sh .
     RUN chmod ugo+x ./entry.sh
     RUN cp /root/setup-db.sql .
 
-# Base checks for sql files
-# TODO: https://github.com/input-output-hk/catalyst-ci/issues/62
+# Linter checks for sql files
 CHECK:
     COMMAND
+
+    RUN sqlfluff lint .
+
 
 # Build PostgreSQL image.
 # REQUIREMENTS: 

--- a/earthly/postgresql/Readme.md
+++ b/earthly/postgresql/Readme.md
@@ -28,6 +28,16 @@ builder:
     COPY --dir ./example/migrations ./example/data ./example/refinery.toml .
     DO +BUILDER
 
+check:
+    LOCALLY
+
+    DO +CHECK --src=$(echo ${PWD})
+
+format:
+    LOCALLY
+
+    DO +FORMAT --src=$(echo ${PWD})
+
 build:
     FROM +builder
 

--- a/earthly/postgresql/example/data/example.sql
+++ b/earthly/postgresql/example/data/example.sql
@@ -1,1 +1,3 @@
-INSERT INTO users (name, age) VALUES ('Alice', 20), ('Bob', 30), ('Charlie', 40);
+INSERT INTO users (name, age) VALUES ('Alice', 20),
+('Bob', 30),
+('Charlie', 40);

--- a/earthly/postgresql/example/docker-compose.yml
+++ b/earthly/postgresql/example/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - DB_HOST=${DB_HOST:-localhost}
       - DB_PORT=5432
       - DB_NAME=ExampleDb
-      - DB_DESCRIPTION="Example DB"
+      - DB_DESCRIPTION=Example DB
       - DB_SUPERUSER=postgres
       - DB_SUPERUSER_PASSWORD=postgres
       - DB_USER=example-dev

--- a/earthly/postgresql/example/migrations/V1__example.sql
+++ b/earthly/postgresql/example/migrations/V1__example.sql
@@ -1,4 +1,3 @@
-
 CREATE TABLE users
 (
   name VARCHAR PRIMARY KEY,

--- a/earthly/postgresql/setup-db.sql
+++ b/earthly/postgresql/setup-db.sql
@@ -15,8 +15,7 @@
 \echo -> dbName ................. = :dbName
 \echo -> dbDescription .......... = :dbDescription
 \echo -> dbUser ................. = :dbUser
-\echo -> dbUserPw / $DB_USER_PW . = :dbUserPw
-
+\echo -> dbUserPw ............... = :dbUserPw
 
 -- Cleanup if we already ran this before.
 DROP DATABASE IF EXISTS :"dbName";
@@ -35,4 +34,3 @@ ALTER DEFAULT privileges IN SCHEMA public REVOKE EXECUTE ON functions FROM :"dbU
 CREATE DATABASE :"dbName" WITH OWNER :"dbUser";
 
 COMMENT ON DATABASE :"dbName" IS :'dbDescription';
-

--- a/earthly/postgresql/setup-db.sql
+++ b/earthly/postgresql/setup-db.sql
@@ -18,19 +18,18 @@
 \echo -> dbUserPw ............... = :dbUserPw
 
 -- Cleanup if we already ran this before.
-DROP DATABASE IF EXISTS :"dbName";
-
-DROP USER IF EXISTS :"dbUser";
+DROP DATABASE IF EXISTS :"dbName"; -- noqa: PRS
+DROP USER IF EXISTS :"dbUser"; -- noqa: PRS
 
 -- Create the test user we will use with the local dev database.
-CREATE USER :"dbUser" WITH PASSWORD :'dbUserPw';
+CREATE USER :"dbUser" WITH PASSWORD :'dbUserPw'; -- noqa: PRS
 
 -- Privileges for this user/role.
 ALTER DEFAULT privileges REVOKE EXECUTE ON functions FROM public;
 
-ALTER DEFAULT privileges IN SCHEMA public REVOKE EXECUTE ON functions FROM :"dbUser";
+ALTER DEFAULT privileges IN SCHEMA public REVOKE EXECUTE ON functions FROM :"dbUser"; -- noqa: PRS
 
 -- Create the database.
-CREATE DATABASE :"dbName" WITH OWNER :"dbUser";
+CREATE DATABASE :"dbName" WITH OWNER :"dbUser"; -- noqa: PRS
 
-COMMENT ON DATABASE :"dbName" IS :'dbDescription';
+COMMENT ON DATABASE :"dbName" IS :'dbDescription'; -- noqa: PRS


### PR DESCRIPTION
- Added `CHECK` and `FORMAT` udcs for the PostgreSQL builder to run sqlfluffy linter on the provided sql files
- Fixed sql files with the lint errors