### PR TITLE
fix: Allow_expect instead of allow _unwrap

### DIFF
--- a/earthly/rust/stdcfgs/clippy.toml
+++ b/earthly/rust/stdcfgs/clippy.toml
@@ -1,1 +1,1 @@
-allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/examples/rust/clippy.toml
+++ b/examples/rust/clippy.toml
@@ -1,1 +1,1 @@
-allow-unwrap-in-tests = true
+allow-expect-in-tests = true


### PR DESCRIPTION
## Description of Changes

Modifing clippy lint to allow only expect in tests instead of unwrap. This should force testers to better comment their code

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
