### PR TITLE
chore: allow Blue Oak license

### DIFF
--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -105,7 +105,8 @@ allow = [
     "MIT",
     "Apache-2.0",
     "Unicode-DFS-2016",
-    "BSD-3-Clause"
+    "BSD-3-Clause",
+    "BlueOak-1.0.0"
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -105,7 +105,8 @@ allow = [
     "MIT",
     "Apache-2.0",
     "Unicode-DFS-2016",
-    "BSD-3-Clause"
+    "BSD-3-Clause",
+    "BlueOak-1.0.0"
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses


### PR DESCRIPTION
# Description

Adds `BlueOak-1.0.0` license to the allowlist in `deny.toml`.

## Related Pull Requests

https://github.com/input-output-hk/hermes/pull/33