### PR TITLE
chore: remove `CP_SRC` UDC

### DIFF
--- a/earthly/cspell/Earthfile
+++ b/earthly/cspell/Earthfile
@@ -18,9 +18,3 @@ CHECK:
     COPY $src .
     
     RUN cspell-cli lint . --dot
-
-# A Test and example invocation of the above UDC.
-cspell-test:
-    # Run with `earthly -P +cspell-test`
-    DO +CHECK --src=$(echo ${PWD}/../../)
-

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -80,20 +80,6 @@ rust-base:
 rust-base-all-hosts:
     BUILD --platform=linux/amd64 --platform=linux/arm64 +rust-base
 
-CP_SRC:
-    # Copy the build src using this.
-    COMMAND
-    # This can be one directory like `"src/*"` or multiple src separated by `","`:
-    # eg, "example/Cargo.toml, example/Cargo.lock, example/src"
-    ARG src=""
-
-    # ONLY copy whats needed to build.  Not everything.
-    # Note: rust-toolchain.toml was already copied when rust was setup.
-    # Minimizing whats copied reduces needless cache misses.
-    FOR --sep=", " file IN $src
-        COPY --dir $file .
-    END
-
 # Common Rust setup.
 # Parameters:
 #  * toolchain : The `rust-toolchain` toml file.


### PR DESCRIPTION
# Description

Remove `CP_SRC` UDC is a redundant command that could be replaced by the common `COPY` command.

## Related Issue(s)

> e.g., Closes #110

## Description of Changes

* Removed `CP_SRC` UDC
* Removed `cspell-test` as it won't be used by other dependencies.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
