### PR TITLE
feat: Unit test alias

### DIFF
--- a/docs/src/guides/languages/rust.md
+++ b/docs/src/guides/languages/rust.md
@@ -9,7 +9,7 @@ tags:
 # :simple-rust: Rust
 <!-- markdownlint-enable single-h1 -->
 
-<!-- cspell: words USERARCH TARGETARCH toolsets fmtchk stdcfgs rustfmt nextest testci testdocs depgraph -->
+<!-- cspell: words USERARCH TARGETARCH toolsets fmtchk stdcfgs rustfmt nextest testunit testdocs depgraph -->
 
 ## Introduction
 
@@ -88,7 +88,7 @@ check-hosted:
 
 # Test which runs check with all supported host tooling.  Needs qemu or rosetta to run.
 # Only used to validate tooling is working across host toolsets.
-check-all-hosts:    
+check-all-hosts:
     BUILD --platform=linux/amd64 --platform=linux/arm64 +check-hosted
 
 ## Standard CI targets.
@@ -144,7 +144,7 @@ The same approach we will see for the another targets of this guide.
 # Build the service.
 build-hosted:
     FROM +builder
- 
+
     DO ./../../earthly/rust+BUILD --libs="bar" --bins="foo/foo"
 
     DO ./../../earthly/rust+SMOKE_TEST --bin="foo"
@@ -154,7 +154,7 @@ build-hosted:
 
 # Test which runs check with all supported host tooling.  Needs qemu or rosetta to run.
 # Only used to validate tooling is working across host toolsets.
-build-all-hosts:    
+build-all-hosts:
     BUILD --platform=linux/amd64 --platform=linux/arm64 +build-hosted
 
 # Run build using the most efficient host tooling
@@ -198,7 +198,7 @@ look at `./earthly/rust/stdcfgs/config.toml`)
 Checking all Clippy Lints in the workspace.
 3. `cargo docs` ([cargo alias](https://doc.rust-lang.org/cargo/reference/config.html#alias),
 look at `./earthly/rust/stdcfgs/config.toml`)Checking Documentation can be generated OK.
-4. `cargo testci` ([cargo alias](https://doc.rust-lang.org/cargo/reference/config.html#alias),
+4. `cargo testunit` ([cargo alias](https://doc.rust-lang.org/cargo/reference/config.html#alias),
 look at `./earthly/rust/stdcfgs/config.toml`)Checking Self contained Unit tests all pass.
 5. `cargo testdocs` ([cargo alias](https://doc.rust-lang.org/cargo/reference/config.html#alias),
 look at `./earthly/rust/stdcfgs/config.toml`)Checking Documentation tests all pass.

--- a/earthly/rust/scripts/std_build.sh
+++ b/earthly/rust/scripts/std_build.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-# cspell: words testci testdocs RUSTDOCFLAGS Zunstable depgraph
+# cspell: words testunit testdocs RUSTDOCFLAGS Zunstable depgraph
 
-# This script is run inside the `check` stage for rust projects to perform all 
+# This script is run inside the `check` stage for rust projects to perform all
 # high level non-compilation checks.
 # These are the Standard checks which ALL rust targets must pass before they
-# will be scheduled to be `build`. 
+# will be scheduled to be `build`.
 # Individual targets can add extra `check` steps, but these checks must always
-# pass. 
+# pass.
 
 source "$(dirname "$0")/colors.sh"
 
@@ -32,7 +32,7 @@ status $rc "Checking Documentation can be generated OK" \
 
 ## Check if all Self contained tests pass (Test that need no external resources).
 status $rc "Checking Self contained Unit tests all pass" \
-    cargo testci; rc=$?
+    cargo testunit; rc=$?
 
 ## Check if all documentation tests pass.
 status $rc "Checking Documentation tests all pass" \

--- a/earthly/rust/stdcfgs/cargo_config.toml
+++ b/earthly/rust/stdcfgs/cargo_config.toml
@@ -1,12 +1,12 @@
 # Use MOLD linker where possible, but ONLY in CI applicable targets.
-# cspell: words rustflags armv gnueabihf msvc nextest idents rustdocflags 
-# cspell: words rustdoc lintfix lintrestrict testfast testdocs codegen testci
+# cspell: words rustflags armv gnueabihf msvc nextest idents rustdocflags
+# cspell: words rustdoc lintfix lintrestrict testfast testdocs codegen testci testunit
 # cspell: words fmtchk fmtfix
 
 # Configure how Docker container targets build.
 
 # If you want to customize these targets for a local build, then customize them in you:
-#  $CARGO_HOME/config.toml  
+#  $CARGO_HOME/config.toml
 # NOT in the project itself.
 # These targets are ONLY the targets used by CI and inside docker builds.
 
@@ -116,6 +116,7 @@ lint-vscode = "clippy --workspace --message-format=json-diagnostic-rendered-ansi
 docs = "doc --workspace -r --all-features --no-deps --bins --document-private-items --examples --locked"
 # nightly docs build broken... when they are'nt we can enable these docs... --unit-graph --timings=html,json -Z unstable-options"
 testfast = "nextest run --release --workspace --locked"
+testunit = "nextest run --release --bins --lib --workspace --locked -P ci"
 testci = "nextest run --release --workspace --locked -P ci"
 testdocs = "test --doc --release --workspace --locked"
 

--- a/examples/rust/.cargo/config.toml
+++ b/examples/rust/.cargo/config.toml
@@ -1,12 +1,12 @@
 # Use MOLD linker where possible, but ONLY in CI applicable targets.
-# cspell: words rustflags armv gnueabihf msvc nextest idents rustdocflags 
-# cspell: words rustdoc lintfix lintrestrict testfast testdocs codegen testci
+# cspell: words rustflags armv gnueabihf msvc nextest idents rustdocflags
+# cspell: words rustdoc lintfix lintrestrict testfast testdocs codegen testci testunit
 # cspell: words fmtchk fmtfix
 
 # Configure how Docker container targets build.
 
 # If you want to customize these targets for a local build, then customize them in you:
-#  $CARGO_HOME/config.toml  
+#  $CARGO_HOME/config.toml
 # NOT in the project itself.
 # These targets are ONLY the targets used by CI and inside docker builds.
 
@@ -116,6 +116,7 @@ lint-vscode = "clippy --workspace --message-format=json-diagnostic-rendered-ansi
 docs = "doc --workspace -r --all-features --no-deps --bins --document-private-items --examples --locked"
 # nightly docs build broken... when they are'nt we can enable these docs... --unit-graph --timings=html,json -Z unstable-options"
 testfast = "nextest run --release --workspace --locked"
+testunit = "nextest run --release --bins --lib --workspace --locked -P ci"
 testci = "nextest run --release --workspace --locked -P ci"
 testdocs = "test --doc --release --workspace --locked"
 


### PR DESCRIPTION
# Description

Adding a new target `testunit` for running  only the unit tests and using it instead of the `testci` one in the build script
Leaving `testci` as it is at the moment but in the future we probably want to only target a subset of tests with it

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
