### PR TITLE
ci: add nightly `wasm32-unknown-unknown` to `rust-base`

### DIFF
--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -49,6 +49,9 @@ rust-base:
     # Install a nightly toolchain which matches.
     RUN rustup toolchain install nightly --component miri --component rust-src --component rustfmt --component clippy
 
+    # Add a target for wasm.
+    RUN rustup target add wasm32-unknown-unknown --toolchain nightly
+
     # Install the default cargo config.
     COPY stdcfgs/cargo_config.toml $CARGO_HOME/config.toml
 

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -49,7 +49,7 @@ rust-base:
     # Install a nightly toolchain which matches.
     RUN rustup toolchain install nightly --component miri --component rust-src --component rustfmt --component clippy
 
-    # Add a target for wasm.
+    # Add a target for wasm.`
     RUN rustup target add wasm32-unknown-unknown --toolchain nightly
 
     # Install the default cargo config.


### PR DESCRIPTION
# Description

Added nightly `wasm32-unknown-unknown` to `rust-base` to build the forked `wasi-preview1-component-adapter`.

## Related Issue(s)

> [32](https://github.com/input-output-hk/hermes/issues/32)

## Description of Changes

* Added nightly `wasm32-unknown-unknown` to `rust-base`

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module