### PR TITLE
feat: UNIT_TEST UDC

### DIFF
--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -46,8 +46,11 @@ rust-base:
     # Make sure we have the clippy linter.
     RUN rustup component add clippy
 
+    # Needed to generate code coverage.
+    RUN rustup component add llvm-tools-preview
+
     # Install a nightly toolchain which matches.
-    RUN rustup toolchain install nightly --component miri --component rust-src --component rustfmt --component clippy --component llvm-tools-preview
+    RUN rustup toolchain install nightly --component miri --component rust-src --component rustfmt --component clippy
 
     # Install the default cargo config.
     COPY stdcfgs/cargo_config.toml $CARGO_HOME/config.toml

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -1,7 +1,7 @@
 # Common Rust UDCs and Builders.
 VERSION 0.7
 
-# cspell: words rustup miri nextest ripgrep colordiff rustfmt stdcfgs toolset readelf depgraph
+# cspell: words rustup miri nextest ripgrep colordiff rustfmt stdcfgs toolset readelf depgraph lcov
 # cspell: words TARGETPLATFORM TARGETOS TARGETARCH TARGETVARIANT USERPLATFORM USEROS USERARCH USERVARIANT
 
 # Base Rustup build container.

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -28,11 +28,11 @@ rust-base:
         echo "USERPLATFORM   = $USERPLATFORM"; \
         echo "USEROS         = $USEROS"; \
         echo "USERARCH       = $USERARCH"; \
-        echo "USERVARIANT    = $USERVARIANT"; 
+        echo "USERVARIANT    = $USERVARIANT";
 
     WORKDIR /root
 
-    # Install necessary packages 
+    # Install necessary packages
     # Expand this list as needed, rather than adding more tools in later containers.
      RUN apk add --no-cache \
             musl-dev \
@@ -47,7 +47,7 @@ rust-base:
     RUN rustup component add clippy
 
     # Install a nightly toolchain which matches.
-    RUN rustup toolchain install nightly --component miri --component rust-src --component rustfmt --component clippy
+    RUN rustup toolchain install nightly --component miri --component rust-src --component rustfmt --component clippy --component llvm-tools-preview
 
     # Install the default cargo config.
     COPY stdcfgs/cargo_config.toml $CARGO_HOME/config.toml
@@ -61,7 +61,8 @@ rust-base:
         cargo install refinery_cli  --version=0.8.11 && \
         cargo install cargo-deny    --version=0.14.3 && \
         cargo install cargo-modules --version=0.10.2 && \
-        cargo install cargo-depgraph --version=1.5.0
+        cargo install cargo-depgraph --version=1.5.0 && \
+        cargo install cargo-llvm-cov --version=0.5.39
 
     SAVE ARTIFACT $CARGO_HOME/bin/refinery refinery
 
@@ -75,7 +76,7 @@ rust-base:
 
 # Builds all the rust-base targets for each supported DOCKER architecture.
 # Currently only used for multi-platform cross build testing.
-# This will ONLY work if you have `qemu` properly setup on linux and `rosetta` for 
+# This will ONLY work if you have `qemu` properly setup on linux and `rosetta` for
 # docker enabled on Mac.
 # Again, this is just a test target, and not for general use.
 rust-base-all-hosts:
@@ -122,6 +123,16 @@ BUILD:
     ARG bins=""
 
     RUN /scripts/std_build.sh "$libs" "$bins"
+
+# Run unit tests and generates test and coverage report artifacts
+UNIT_TEST:
+    COMMAND
+    # remove artifacts that may affect the coverage results
+    RUN cargo llvm-cov clean --workspace
+    # run unit tests and display test result and test coverage
+    RUN cargo llvm-cov nextest --release --bins --lib --workspace --locked -P ci
+    # generate lcov report
+    RUN cargo llvm-cov report --release --output-path coverage-report.info
 
 # Check if the build executable, isn't a busted mess.
 SMOKE_TEST:

--- a/earthly/rust/scripts/std_build.sh
+++ b/earthly/rust/scripts/std_build.sh
@@ -30,10 +30,6 @@ status $rc "Checking all Clippy Lints in the workspace" \
 status $rc "Checking Documentation can be generated OK" \
     cargo +nightly docs; rc=$?
 
-## Check if all Self contained tests pass (Test that need no external resources).
-status $rc "Checking Self contained Unit tests all pass" \
-    cargo testunit; rc=$?
-
 ## Check if all documentation tests pass.
 status $rc "Checking Documentation tests all pass" \
     cargo +nightly testdocs; rc=$?

--- a/earthly/rust/stdcfgs/cargo_config.toml
+++ b/earthly/rust/stdcfgs/cargo_config.toml
@@ -115,9 +115,7 @@ lint-vscode = "clippy --workspace --message-format=json-diagnostic-rendered-ansi
 
 docs = "doc --workspace -r --all-features --no-deps --bins --document-private-items --examples --locked"
 # nightly docs build broken... when they are'nt we can enable these docs... --unit-graph --timings=html,json -Z unstable-options"
-testfast = "nextest run --release --workspace --locked"
-testunit = "nextest run --release --bins --lib --workspace --locked -P ci"
-testci = "nextest run --release --workspace --locked -P ci"
+testfast = "nextest --release --workspace --locked"
 testdocs = "test --doc --release --workspace --locked"
 
 # Rust formatting, MUST be run with +nightly

--- a/examples/rust/.cargo/config.toml
+++ b/examples/rust/.cargo/config.toml
@@ -115,9 +115,7 @@ lint-vscode = "clippy --workspace --message-format=json-diagnostic-rendered-ansi
 
 docs = "doc --workspace -r --all-features --no-deps --bins --document-private-items --examples --locked"
 # nightly docs build broken... when they are'nt we can enable these docs... --unit-graph --timings=html,json -Z unstable-options"
-testfast = "nextest run --release --workspace --locked"
-testunit = "nextest run --release --bins --lib --workspace --locked -P ci"
-testci = "nextest run --release --workspace --locked -P ci"
+testfast = "nextest --release --workspace --locked"
 testdocs = "test --doc --release --workspace --locked"
 
 # Rust formatting, MUST be run with +nightly

--- a/examples/rust/Earthfile
+++ b/examples/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.7
 
-# cspell: words TARGETARCH USERARCH toolsets rustfmt
+# cspell: words TARGETARCH USERARCH toolsets rustfmt nextest
 
 # Set up our target toolchains, and copy our files.
 builder:

--- a/examples/rust/Earthfile
+++ b/examples/rust/Earthfile
@@ -20,24 +20,29 @@ check-hosted:
 
 # Test which runs check with all supported host tooling.  Needs qemu or rosetta to run.
 # Only used to validate tooling is working across host toolsets.
-check-all-hosts:    
+check-all-hosts:
     BUILD --platform=linux/amd64 --platform=linux/arm64 +check-hosted
 
 
 # Build the service.
 build-hosted:
     FROM +builder
- 
+
     DO ./../../earthly/rust+BUILD --libs="bar" --bins="foo/foo"
+
+    DO ./../../earthly/rust+UNIT_TEST
 
     DO ./../../earthly/rust+SMOKE_TEST --bin="foo"
 
     SAVE ARTIFACT target/$TARGETARCH/doc doc
     SAVE ARTIFACT target/$TARGETARCH/release/foo foo
+    SAVE ARTIFACT target/$TARGETARCH/nextest/ci/junit.xml junit-report.xml
+    SAVE ARTIFACT coverage-report.info coverage-report.info
+
 
 # Test which runs check with all supported host tooling.  Needs qemu or rosetta to run.
 # Only used to validate tooling is working across host toolsets.
-build-all-hosts:    
+build-all-hosts:
     BUILD --platform=linux/amd64 --platform=linux/arm64 +build-hosted
 
 ## -----------------------------------------------------------------------------

--- a/examples/rust/Earthfile
+++ b/examples/rust/Earthfile
@@ -30,20 +30,23 @@ build-hosted:
 
     DO ./../../earthly/rust+BUILD --libs="bar" --bins="foo/foo"
 
-    DO ./../../earthly/rust+UNIT_TEST
-
     DO ./../../earthly/rust+SMOKE_TEST --bin="foo"
 
     SAVE ARTIFACT target/$TARGETARCH/doc doc
     SAVE ARTIFACT target/$TARGETARCH/release/foo foo
-    SAVE ARTIFACT target/$TARGETARCH/nextest/ci/junit.xml junit-report.xml
-    SAVE ARTIFACT coverage-report.info coverage-report.info
-
 
 # Test which runs check with all supported host tooling.  Needs qemu or rosetta to run.
 # Only used to validate tooling is working across host toolsets.
 build-all-hosts:
     BUILD --platform=linux/amd64 --platform=linux/arm64 +build-hosted
+
+test-hosted:
+    FROM +builder
+
+    DO ./../../earthly/rust+UNIT_TEST
+
+    SAVE ARTIFACT target/$TARGETARCH/nextest/ci/junit.xml junit-report.xml
+    SAVE ARTIFACT coverage-report.info coverage-report.info
 
 ## -----------------------------------------------------------------------------
 ##
@@ -81,7 +84,21 @@ build:
         BUILD --platform=linux/amd64 +build-hosted
     END
 
+test:
+    FROM busybox
+    # This is necessary to pick the correct architecture build to suit the native machine.
+    # It primarily ensures that Darwin/Arm builds work as expected without needing x86 emulation.
+    # All target implementation of this should follow this pattern.
+    ARG USERARCH
+
+    IF [ "$USERARCH" == "arm64" ]
+        BUILD --platform=linux/arm64 +test-hosted
+    ELSE
+        BUILD --platform=linux/amd64 +test-hosted
+    END
+
 # This step simulates the full CI run for local purposes only.
 local-ci-run:
     BUILD +check
     BUILD +build
+    BUILD +test

--- a/examples/rust/Earthfile
+++ b/examples/rust/Earthfile
@@ -45,7 +45,7 @@ test-hosted:
 
     DO ./../../earthly/rust+UNIT_TEST
 
-    SAVE ARTIFACT target/$TARGETARCH/nextest/ci/junit.xml junit-report.xml
+    SAVE ARTIFACT target/nextest/ci/junit.xml junit-report.xml
     SAVE ARTIFACT coverage-report.info coverage-report.info
 
 ## -----------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Adding a UNIT_TEST UDC . This UDC will run unit tests and produce code coverage info using [LLVM instrumentation-based coverage](https://doc.rust-lang.org/rustc/instrument-coverage.html) with the help of [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) that supports nextest. The code coverage info will be printed on the stout after the test results as a support for the devs and will be also saved as an artifact to be used in CI.
Nextest will also create a test report in junit format that can be saved as artifact and used in CI.
The unit test alias and the testci alias have been removed as they will be substitute with a earthly target

## Related Issue(s)

List the issue numbers related to this pull request.

> e.g., Closes #123, Resolves #456  Fixes #367

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
