### PR TITLE
fix: Move target flags after target

### DIFF
--- a/actions/run/dist/index.js
+++ b/actions/run/dist/index.js
@@ -556,8 +556,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n
-        Error Code : ${error.statusCode}\n
+                throw new Error(`Failed to get ID Token. \n 
+        Error Code : ${error.statusCode}\n 
         Error Message: ${error.result.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -2814,7 +2814,7 @@ module.exports = require("util");
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/
+/******/ 	
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -2828,7 +2828,7 @@ module.exports = require("util");
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/
+/******/ 	
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -2837,11 +2837,11 @@ module.exports = require("util");
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/
+/******/ 	
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/
+/******/ 	
 /************************************************************************/
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
@@ -2853,11 +2853,11 @@ module.exports = require("util");
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/
+/******/ 	
 /******/ 	/* webpack/runtime/compat */
-/******/
+/******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/
+/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be in strict mode.

--- a/actions/run/dist/index.js
+++ b/actions/run/dist/index.js
@@ -556,8 +556,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+                throw new Error(`Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.result.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -2814,7 +2814,7 @@ module.exports = require("util");
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -2828,7 +2828,7 @@ module.exports = require("util");
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -2837,11 +2837,11 @@ module.exports = require("util");
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
@@ -2853,11 +2853,11 @@ module.exports = require("util");
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/ 	
+/******/
 /******/ 	/* webpack/runtime/compat */
-/******/ 	
+/******/
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
+/******/
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be in strict mode.
@@ -2902,9 +2902,6 @@ async function run() {
     if (flags) {
         args.push(...flags.split(' '));
     }
-    if (targetFlags) {
-        args.push(...targetFlags.split(' '));
-    }
     core.info(`Filtered targets >> ${targets}`);
     targets.split(' ').map(tg => {
         // Get the filtered targets associated with the pattern target and earthfile.
@@ -2922,6 +2919,9 @@ async function run() {
         }
         else {
             argsSpawn.push(t);
+        }
+        if (targetFlags) {
+            args.push(...targetFlags.split(' '));
         }
         core.info(`Running command: ${command} ${argsSpawn.join(' ')}`);
         const output = await spawnCommand(command, argsSpawn);

--- a/actions/run/dist/index.js
+++ b/actions/run/dist/index.js
@@ -2921,7 +2921,7 @@ async function run() {
             argsSpawn.push(t);
         }
         if (targetFlags) {
-            args.push(...targetFlags.split(' '));
+            argsSpawn.push(...targetFlags.split(' '));
         }
         core.info(`Running command: ${command} ${argsSpawn.join(' ')}`);
         const output = await spawnCommand(command, argsSpawn);

--- a/actions/run/src/run.test.ts
+++ b/actions/run/src/run.test.ts
@@ -32,8 +32,8 @@ describe('Run Action', () => {
         runnerAddress: '',
         runnerPort: '',
         targets: 'target',
-        command: [['--flag1', 'test', '-f2', 'test2', './earthfile+target']],
         targetFlags: '--flag1 test -f2 test2',
+        command: [['./earthfile+target', '--flag1', 'test', '-f2', 'test2']],
         imageOutput: '',
         artifactOutput: ''
       },
@@ -48,8 +48,8 @@ describe('Run Action', () => {
         runnerAddress: '',
         runnerPort: '',
         targets: 'target',
-        command: [['--test', '--artifact', './earthfile+target/', 'out']],
         targetFlags: '',
+        command: [['--test', '--artifact', './earthfile+target/', 'out']],
         imageOutput: '',
         artifactOutput: 'earthfile/out'
       },
@@ -64,10 +64,10 @@ describe('Run Action', () => {
         runnerAddress: 'localhost',
         runnerPort: '8372',
         targets: 'target',
+        targetFlags: '',
         command: [
           ['--buildkit-host', 'tcp://localhost:8372', './earthfile+target']
         ],
-        targetFlags: '',
         imageOutput: '',
         artifactOutput: ''
       },
@@ -82,6 +82,7 @@ describe('Run Action', () => {
         runnerAddress: '',
         runnerPort: '',
         targets: 'target',
+        targetFlags: '',
         command: [
           [
             '-P',
@@ -94,7 +95,6 @@ describe('Run Action', () => {
             './earthfile+target'
           ]
         ],
-        targetFlags: '',
         imageOutput: 'image1:tag1',
         artifactOutput: ''
       },
@@ -109,11 +109,11 @@ describe('Run Action', () => {
         runnerAddress: '',
         runnerPort: '',
         targets: 'target target-test',
+        targetFlags: '',
         command: [
           ['-P', '--platform', 'linux/amd64', './targets/earthfile+target'],
           ['-P', '--platform', 'linux/amd64', './targets/earthfile+target-test']
         ],
-        targetFlags: '',
         imageOutput: '',
         artifactOutput: ''
       }
@@ -130,8 +130,8 @@ describe('Run Action', () => {
         runnerAddress,
         runnerPort,
         targets,
-        command,
         targetFlags,
+        command,
         imageOutput,
         artifactOutput
       }) => {

--- a/actions/run/src/run.test.ts
+++ b/actions/run/src/run.test.ts
@@ -32,8 +32,8 @@ describe('Run Action', () => {
         runnerAddress: '',
         runnerPort: '',
         targets: 'target',
-        targetFlags: '--flag1 test -f2 test2',
         command: [['--flag1', 'test', '-f2', 'test2', './earthfile+target']],
+        targetFlags: '--flag1 test -f2 test2',
         imageOutput: '',
         artifactOutput: ''
       },
@@ -48,8 +48,8 @@ describe('Run Action', () => {
         runnerAddress: '',
         runnerPort: '',
         targets: 'target',
-        targetFlags: '',
         command: [['--test', '--artifact', './earthfile+target/', 'out']],
+        targetFlags: '',
         imageOutput: '',
         artifactOutput: 'earthfile/out'
       },
@@ -64,10 +64,10 @@ describe('Run Action', () => {
         runnerAddress: 'localhost',
         runnerPort: '8372',
         targets: 'target',
-        targetFlags: '',
         command: [
           ['--buildkit-host', 'tcp://localhost:8372', './earthfile+target']
         ],
+        targetFlags: '',
         imageOutput: '',
         artifactOutput: ''
       },
@@ -82,7 +82,6 @@ describe('Run Action', () => {
         runnerAddress: '',
         runnerPort: '',
         targets: 'target',
-        targetFlags: '',
         command: [
           [
             '-P',
@@ -95,6 +94,7 @@ describe('Run Action', () => {
             './earthfile+target'
           ]
         ],
+        targetFlags: '',
         imageOutput: 'image1:tag1',
         artifactOutput: ''
       },
@@ -109,11 +109,11 @@ describe('Run Action', () => {
         runnerAddress: '',
         runnerPort: '',
         targets: 'target target-test',
-        targetFlags: '',
         command: [
           ['-P', '--platform', 'linux/amd64', './targets/earthfile+target'],
           ['-P', '--platform', 'linux/amd64', './targets/earthfile+target-test']
         ],
+        targetFlags: '',
         imageOutput: '',
         artifactOutput: ''
       }
@@ -130,8 +130,8 @@ describe('Run Action', () => {
         runnerAddress,
         runnerPort,
         targets,
-        targetFlags,
         command,
+        targetFlags,
         imageOutput,
         artifactOutput
       }) => {

--- a/actions/run/src/run.ts
+++ b/actions/run/src/run.ts
@@ -34,10 +34,6 @@ export async function run(): Promise<void> {
     args.push(...flags.split(' '))
   }
 
-  if (targetFlags) {
-    args.push(...targetFlags.split(' '))
-  }
-
   core.info(`Filtered targets >> ${targets}`)
 
   targets.split(' ').map(tg => {
@@ -57,6 +53,11 @@ export async function run(): Promise<void> {
     } else {
       argsSpawn.push(t)
     }
+
+    if (targetFlags) {
+      argsSpawn.push(...targetFlags.split(' '))
+    }
+
     core.info(`Running command: ${command} ${argsSpawn.join(' ')}`)
     const output = await spawnCommand(command, argsSpawn)
     const imageOutput = parseImage(output)


### PR DESCRIPTION
# Description

Fixing target flags being parsed after the target leading to errors like this https://github.com/input-output-hk/catalyst-artifacts/actions/runs/7478641429/job/20354035906#step:7:39

## Description of Changes

Moved target flags parsing after target

## Breaking Changes

Describe any breaking changes and the impact.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

If applicable, list any related pull requests.

> e.g., #123, #456

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
