### PR TITLE
fix: allow target to have multiple hyphenated alphanumeric sequence

### DIFF
--- a/cli/pkg/scanners/file_scanner.go
+++ b/cli/pkg/scanners/file_scanner.go
@@ -80,7 +80,8 @@ func getTargetRegex(target string) string {
 	if strings.HasSuffix(target, "-*") {
 		// Should start with given target
 		// followed by hyphen and followed by one or more lowercase letters or numbers
-		return fmt.Sprintf("^%s-(?:[a-z0-9]+)?$", regexp.QuoteMeta(target[:len(target)-2]))
+		// allows for additional hyphenated alphanumeric sequences
+		return fmt.Sprintf("^%s-[a-z0-9]+(?:-[a-z0-9]+)*$", regexp.QuoteMeta(target[:len(target)-2]))
 	}
 
 	// Match the exact target

--- a/cli/pkg/scanners/file_scanner_test.go
+++ b/cli/pkg/scanners/file_scanner_test.go
@@ -113,6 +113,8 @@ var _ = Describe("FileScanner", func() {
 			},
 			Entry("scanning 'docker', target in file is 'docker'", "docker", "docker"),
 			Entry("scanning 'docker-*', target in file is 'docker-test'", "docker-*", "docker-test"),
+			Entry("scanning 'docker-*', target in file is 'docker-test-test2'", "docker-*", "docker-test-test2"),
+			Entry("scanning 'docker-*', target in file is 'docker-test-test2-test3'", "docker-*", "docker-test-test2-test3"),
 		)
 		DescribeTable("when Earthfile contain no target",
 			func(target string) {

--- a/docs/src/onboarding/index.md
+++ b/docs/src/onboarding/index.md
@@ -57,7 +57,7 @@ The output of the check phase may looks like the following:
 
 ```json
 {
-  "/home/work/test": ["check-test1", "check-test2", "check-test3"],
+  "/home/work/test": ["check-test1", "check-test2", "check-test3", "check-test-test4"],
   "/home/work/test2": ["check"]
 }
 ```
@@ -71,7 +71,8 @@ The output of the check phase may looks like the following:
 This list of `path` is fed into a [matrix job](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) that
 multiplexes executing the filtered targets from each of the discovered `Earthfile`s.
 The filtered targets will be retrieved from the map according to which Earthfile is currently running.
-For example, from the above example, running `/home/work/test` will run the targets `check-test1`, `check-test2`, and `check-test3`.
+For example, from the above example, running `/home/work/test` will run the targets `check-test1`, `check-test2`, `check-test3` and
+`check-test-test4`.
 
 Executing each discovered Earthfile in parallel will maximize network throughput
 and create a more easily digestible view of the CI status.
@@ -183,7 +184,7 @@ The examples are provided below:
 
 ```json
 {
-  "/home/work/test": ["check-test1", "check-test2", "check-test3"],
+  "/home/work/test": ["check-test1", "check-test2", "check-test3", "check-test-test4"],
   "/home/work/test2": ["check-test1"]
 }
 ```


### PR DESCRIPTION
# Description

allow target to have multiple hyphenated alphanumeric sequence

## Related Issue(s)

## Description of Changes
- Add test case for `target-test-test2` and `target-test-test3`
- Fix doc
- Fix regex to allow multiple hyphenated alphanumeric sequence
## Breaking Changes


## Screenshots


## Related Pull Requests


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
