### PR TITLE
feat: Add `cargo-expand` to the Rust builder

### DIFF
--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -77,6 +77,7 @@ rust-base:
         cargo install cargo-depgraph --version=1.6.0 && \
         cargo install cargo-llvm-cov --version=0.6.4 && \
         cargo install wasm-tools --version=1.0.57 && \
+        cargo install cargo-expand --version=1.0.79 && \
         cargo install --git https://github.com/bytecodealliance/wasmtime --tag v17.0.0 verify-component-adapter && \
         cargo install --git https://github.com/bytecodealliance/wit-bindgen --rev 442f005 wit-bindgen-cli
 


### PR DESCRIPTION
# Description

Added [`cargo-expand`](https://github.com/dtolnay/cargo-expand) tool into the Rust builder  
