### PR TITLE
build(cargo deny): allow

### DIFF
--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -188,7 +188,7 @@ registries = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "warn"
+wildcards = "deny"
 # The graph highlighting used when creating dotgraphs for crates
 # with multiple versions
 # * lowest-version - The path to the lowest versioned duplicate is highlighted

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -188,7 +188,7 @@ registries = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "deny"
+wildcards = "warn"
 # The graph highlighting used when creating dotgraphs for crates
 # with multiple versions
 # * lowest-version - The path to the lowest versioned duplicate is highlighted
@@ -271,7 +271,8 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     # Remove this once upstream changes are merged.
     # issue: https://github.com/input-output-hk/hermes/issues/63
-    "https://github.com/input-output-hk/catalyst-pallas"
+    "https://github.com/input-output-hk/catalyst-pallas",
+    "https://github.com/input-output-hk/hermes.git"
 ]
 
 [sources.allow-org]

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -269,9 +269,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    # Remove this once upstream changes are merged.
-    # issue: https://github.com/input-output-hk/hermes/issues/63
-    "https://github.com/input-output-hk/catalyst-pallas",
     "https://github.com/input-output-hk/hermes.git"
 ]
 

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -188,7 +188,7 @@ registries = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "warn"
+wildcards = "deny"
 # The graph highlighting used when creating dotgraphs for crates
 # with multiple versions
 # * lowest-version - The path to the lowest versioned duplicate is highlighted

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -188,7 +188,7 @@ registries = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "deny"
+wildcards = "warn"
 # The graph highlighting used when creating dotgraphs for crates
 # with multiple versions
 # * lowest-version - The path to the lowest versioned duplicate is highlighted
@@ -271,7 +271,8 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     # Remove this once upstream changes are merged.
     # issue: https://github.com/input-output-hk/hermes/issues/63
-    "https://github.com/input-output-hk/catalyst-pallas"
+    "https://github.com/input-output-hk/catalyst-pallas",
+     "https://github.com/input-output-hk/hermes.git"
 ]
 
 [sources.allow-org]

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -269,9 +269,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    # Remove this once upstream changes are merged.
-    # issue: https://github.com/input-output-hk/hermes/issues/63
-    "https://github.com/input-output-hk/catalyst-pallas",
     "https://github.com/input-output-hk/hermes.git"
 ]
 

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -272,7 +272,7 @@ allow-git = [
     # Remove this once upstream changes are merged.
     # issue: https://github.com/input-output-hk/hermes/issues/63
     "https://github.com/input-output-hk/catalyst-pallas",
-     "https://github.com/input-output-hk/hermes.git"
+    "https://github.com/input-output-hk/hermes.git"
 ]
 
 [sources.allow-org]

--- a/utilities/dbviz/deny.toml
+++ b/utilities/dbviz/deny.toml
@@ -188,7 +188,7 @@ registries = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "warn"
+wildcards = "deny"
 # The graph highlighting used when creating dotgraphs for crates
 # with multiple versions
 # * lowest-version - The path to the lowest versioned duplicate is highlighted

--- a/utilities/dbviz/deny.toml
+++ b/utilities/dbviz/deny.toml
@@ -271,7 +271,8 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     # Remove this once upstream changes are merged.
     # issue: https://github.com/input-output-hk/hermes/issues/63
-    "https://github.com/input-output-hk/catalyst-pallas"
+    "https://github.com/input-output-hk/catalyst-pallas",
+    "https://github.com/input-output-hk/hermes.git"
 ]
 
 [sources.allow-org]

--- a/utilities/dbviz/deny.toml
+++ b/utilities/dbviz/deny.toml
@@ -188,7 +188,7 @@ registries = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "deny"
+wildcards = "warn"
 # The graph highlighting used when creating dotgraphs for crates
 # with multiple versions
 # * lowest-version - The path to the lowest versioned duplicate is highlighted

--- a/utilities/dbviz/deny.toml
+++ b/utilities/dbviz/deny.toml
@@ -269,9 +269,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    # Remove this once upstream changes are merged.
-    # issue: https://github.com/input-output-hk/hermes/issues/63
-    "https://github.com/input-output-hk/catalyst-pallas",
     "https://github.com/input-output-hk/hermes.git"
 ]
 


### PR DESCRIPTION
Unable to pass cargo deny without the following. Problems came about after adding `cardano-follower` dependency.

We don't have versioning on the cardano-follower hence wildcard issue. Plus we need to whitelist hermes git repo.