### PR TITLE
fix: Downgrade rust-base alpine version to 3.18

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -73,6 +73,7 @@ rustdoc
 rustdocflags
 rustfmt
 codegen
+libgcc
 lintfix
 testunit
 nextest

--- a/earthly/docs/Earthfile
+++ b/earthly/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION --global-cache --use-function-keyword 0.7
 
-# cspell: words libgcc freetype lcms openjpeg etag
+# cspell: words freetype lcms openjpeg etag
 
 deps:
     FROM ../python+python-base

--- a/earthly/python/Earthfile
+++ b/earthly/python/Earthfile
@@ -1,8 +1,6 @@
 # Common Python UDCs and Builders.
 VERSION --global-cache --use-function-keyword 0.7
 
-# cspell: words libgcc
-
 python-base:
     FROM python:3.12-alpine3.19
 

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -21,6 +21,12 @@ rust-base:
     # The ACTUAL version of rust that will be used, and available targets
     # is controlled by a `rust-toolchain.toml` file when the `SETUP` UDC is run.
     # HOWEVER, It is enforced that the rust version in `rust-toolchain.toml` MUST match this version.
+
+    # WARNING:
+    # Dont bump the version of the alpine.
+    # A potential bug was found inside `libgcc:13` version.
+    # It works fine with the `libgcc:12` version.
+    # Look: https://github.com/bytecodealliance/wasmtime/issues/7997
     FROM rust:1.75-alpine3.18
 
     RUN echo "TARGETPLATFORM = $TARGETPLATFORM"; \

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -21,7 +21,7 @@ rust-base:
     # The ACTUAL version of rust that will be used, and available targets
     # is controlled by a `rust-toolchain.toml` file when the `SETUP` UDC is run.
     # HOWEVER, It is enforced that the rust version in `rust-toolchain.toml` MUST match this version.
-    FROM rust:1.75-alpine3.19
+    FROM rust:1.75-alpine3.18
 
     RUN echo "TARGETPLATFORM = $TARGETPLATFORM"; \
         echo "TARGETOS       = $TARGETOS"; \
@@ -78,8 +78,8 @@ rust-base:
         cargo install cargo-llvm-cov --version=0.6.4 && \
         cargo install wasm-tools --version=1.0.57 && \
         cargo install cargo-expand --version=1.0.79 && \
-        cargo install --git https://github.com/bytecodealliance/wasmtime --tag v17.0.0 verify-component-adapter && \
-        cargo install --git https://github.com/bytecodealliance/wit-bindgen --rev 442f005 wit-bindgen-cli
+        cargo install wit-bindgen-cli --version=0.17.0 && \
+        cargo install --git https://github.com/bytecodealliance/wasmtime --tag v17.0.0 verify-component-adapter
 
     SAVE ARTIFACT $CARGO_HOME/bin/refinery refinery
     SAVE ARTIFACT $CARGO_HOME/bin/wasm-tools wasm-tools


### PR DESCRIPTION
# Description

Downgrade an alpine version to `3.18` for `rust-base`. 
We have encountered a problems with using `libgcc:13` which goes with `alpine:3.19`.


## Related Pull Requests

fixes https://github.com/input-output-hk/hermes/pull/109