### PR TITLE
fix: Downgrade cargo-deny version from failed cargo-deny `v0.14.17`

### DIFF
--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -78,6 +78,7 @@ rust-base:
     RUN cargo install cargo-nextest --version=0.9.68 && \
         cargo install cargo-machete --version=0.6.1  && \
         cargo install refinery_cli  --version=0.8.12 && \
+        # TODO: https://github.com/input-output-hk/catalyst-ci/issues/214
         cargo install cargo-deny    --version=0.14.10 && \
         cargo install cargo-modules --version=0.14.0 && \
         cargo install cargo-depgraph --version=1.6.0 && \

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -78,7 +78,7 @@ rust-base:
     RUN cargo install cargo-nextest --version=0.9.68 && \
         cargo install cargo-machete --version=0.6.1  && \
         cargo install refinery_cli  --version=0.8.12 && \
-        cargo install cargo-deny    --version=0.14.17 && \
+        cargo install cargo-deny    --version=0.14.18 && \
         cargo install cargo-modules --version=0.14.0 && \
         cargo install cargo-depgraph --version=1.6.0 && \
         cargo install cargo-llvm-cov --version=0.6.8 && \

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -78,7 +78,7 @@ rust-base:
     RUN cargo install cargo-nextest --version=0.9.68 && \
         cargo install cargo-machete --version=0.6.1  && \
         cargo install refinery_cli  --version=0.8.12 && \
-        cargo install cargo-deny    --version=0.14.18 && \
+        cargo install cargo-deny    --version=0.14.10 && \
         cargo install cargo-modules --version=0.14.0 && \
         cargo install cargo-depgraph --version=1.6.0 && \
         cargo install cargo-llvm-cov --version=0.6.8 && \


### PR DESCRIPTION
# Description

Downgrade `cargo-deny` to `v0.14.10` from failed `v0.14.17`.
Here is the log of failure `v0.14.17` version.

https://github.com/EmbarkStudios/cargo-deny/pull/638

```sh
  ./e/rust+rust-base *failed* |    Compiling cargo-deny v0.14.17
  ./e/rust+rust-base *failed* | error[E0308]: arguments to this function are incorrect
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-deny-0.14.17/src/advisories/helpers/db.rs:259:30
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 259 |         let remote_head_id = tame_index::utils::git::write_fetch_head(&repo, &outcome, &remote)
  ./e/rust+rust-base *failed* |     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -----  --------  ------- expected `Remote<'_>`, found `gix::Remote<'_>`
  ./e/rust+rust-base *failed* |     |                                                                       |      |
  ./e/rust+rust-base *failed* |     |                                                                       |      expected `Outcome`, found `gix::remote::fetch::Outcome`
  ./e/rust+rust-base *failed* |     |                                                                       expected `&Repository`, found `&CommitAutoRollback<'_>`
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* |     = note: expected reference `&tame_index::external::gix::Repository`
  ./e/rust+rust-base *failed* |                found reference `&gix::config::CommitAutoRollback<'_>`
  ./e/rust+rust-base *failed* |     = note: `gix::remote::fetch::Outcome` and `Outcome` have similar names, but are actually distinct types
  ./e/rust+rust-base *failed* | note: `gix::remote::fetch::Outcome` is defined in crate `gix`
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.60.0/src/remote/connection/fetch/mod.rs:72:1
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 72  | pub struct Outcome {
  ./e/rust+rust-base *failed* |     | ^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* | note: `Outcome` is defined in crate `gix`
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.58.0/src/remote/connection/fetch/mod.rs:72:1
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 72  | pub struct Outcome {
  ./e/rust+rust-base *failed* |     | ^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* |     = note: perhaps two different versions of crate `gix` are being used?
  ./e/rust+rust-base *failed* |     = note: `gix::Remote<'_>` and `Remote<'_>` have similar names, but are actually distinct types
  ./e/rust+rust-base *failed* | note: `gix::Remote<'_>` is defined in crate `gix`
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.60.0/src/types.rs:200:1
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 200 | pub struct Remote<'repo> {
  ./e/rust+rust-base *failed* |     | ^^^^^^^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* | note: `Remote<'_>` is defined in crate `gix`
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.58.0/src/types.rs:200:1
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 200 | pub struct Remote<'repo> {
  ./e/rust+rust-base *failed* |     | ^^^^^^^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* |     = note: perhaps two different versions of crate `gix` are being used?
  ./e/rust+rust-base *failed* | note: function defined here
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/tame-index-0.9.7/src/utils/git.rs:27:8
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 27  | pub fn write_fetch_head(
  ./e/rust+rust-base *failed* |     |        ^^^^^^^^^^^^^^^^

  ./e/rust+rust-base *failed* | error[E0308]: arguments to this function are incorrect
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-deny-0.14.17/src/advisories/helpers/db.rs:444:9
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 444 |         tame_index::utils::git::write_fetch_head(
  ./e/rust+rust-base *failed* |     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* | 445 |             &repo,
  ./e/rust+rust-base *failed* |     |             ----- expected `Repository`, found `gix::Repository`
  ./e/rust+rust-base *failed* | 446 |             &fetch_outcome,
  ./e/rust+rust-base *failed* |     |             -------------- expected `Outcome`, found `gix::remote::fetch::Outcome`
  ./e/rust+rust-base *failed* | 447 |             &repo.find_remote("origin").unwrap(),
  ./e/rust+rust-base *failed* |     |             ------------------------------------ expected `Remote<'_>`, found `gix::Remote<'_>`
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* |     = note: `gix::Repository` and `Repository` have similar names, but are actually distinct types
  ./e/rust+rust-base *failed* | note: `gix::Repository` is defined in crate `gix`
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.60.0/src/types.rs:144:1
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 144 | pub struct Repository {
  ./e/rust+rust-base *failed* |     | ^^^^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* | note: `Repository` is defined in crate `gix`
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.58.0/src/types.rs:144:1
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 144 | pub struct Repository {
  ./e/rust+rust-base *failed* |     | ^^^^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* |     = note: perhaps two different versions of crate `gix` are being used?
  ./e/rust+rust-base *failed* |     = note: `gix::remote::fetch::Outcome` and `Outcome` have similar names, but are actually distinct types
  ./e/rust+rust-base *failed* | note: `gix::remote::fetch::Outcome` is defined in crate `gix`
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.60.0/src/remote/connection/fetch/mod.rs:72:1
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 72  | pub struct Outcome {
  ./e/rust+rust-base *failed* |     | ^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* | note: `Outcome` is defined in crate `gix`
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.58.0/src/remote/connection/fetch/mod.rs:72:1
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 72  | pub struct Outcome {
  ./e/rust+rust-base *failed* |     | ^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* |     = note: perhaps two different versions of crate `gix` are being used?
  ./e/rust+rust-base *failed* |     = note: `gix::Remote<'_>` and `Remote<'_>` have similar names, but are actually distinct types
  ./e/rust+rust-base *failed* | note: `gix::Remote<'_>` is defined in crate `gix`
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.60.0/src/types.rs:200:1
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 200 | pub struct Remote<'repo> {
  ./e/rust+rust-base *failed* |     | ^^^^^^^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* | note: `Remote<'_>` is defined in crate `gix`
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-0.58.0/src/types.rs:200:1
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 200 | pub struct Remote<'repo> {
  ./e/rust+rust-base *failed* |     | ^^^^^^^^^^^^^^^^^^^^^^^^
  ./e/rust+rust-base *failed* |     = note: perhaps two different versions of crate `gix` are being used?
  ./e/rust+rust-base *failed* | note: function defined here
  ./e/rust+rust-base *failed* |    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/tame-index-0.9.7/src/utils/git.rs:27:8
  ./e/rust+rust-base *failed* |     |
  ./e/rust+rust-base *failed* | 27  | pub fn write_fetch_head(
  ./e/rust+rust-base *failed* |     |        ^^^^^^^^^^^^^^^^

  ./e/rust+rust-base *failed* | For more information about this error, try `rustc --explain E0308`.
  ./e/rust+rust-base *failed* | error: could not compile `cargo-deny` (lib) due to 2 previous errors
 ```