### PR TITLE
feat: Python builder, install `rich`

### DIFF
--- a/earthly/python/Earthfile
+++ b/earthly/python/Earthfile
@@ -35,6 +35,7 @@ python-base:
 
     # Install ruff for linting.
     RUN pip3 install ruff
+    RUN pip3 install rich
 
     # Universal build scripts we will always need and are not target dependent.
     COPY --dir scripts /scripts


### PR DESCRIPTION
# Description

Updated python builder, install `rich` dependency which are used by our builder scripts 

needed for: https://github.com/input-output-hk/catalyst-voices/pull/341