### PR TITLE
fix: Python builder, remove Readme.md copying

### DIFF
--- a/earthly/python/Earthfile
+++ b/earthly/python/Earthfile
@@ -49,7 +49,7 @@ BUILDER:
     ARG opts
 
     # Copy our dependencies.
-    COPY pyproject.toml poetry.lock Readme.md .
+    COPY pyproject.toml poetry.lock .
 
     # Install it all with poetry
     RUN poetry install $opts    


### PR DESCRIPTION
# Description

Fixing python builder, removed unnecessary `Readme.md` copying