### PR TITLE
fix: Add "https://github.com/input-output-hk/catalyst-pallas.git" to deny.toml

### DIFF
--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -270,7 +270,8 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/input-output-hk/hermes.git"
+    "https://github.com/input-output-hk/hermes.git",
+    "https://github.com/input-output-hk/catalyst-pallas.git"
 ]
 
 [sources.allow-org]

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -270,7 +270,8 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/input-output-hk/hermes.git"
+    "https://github.com/input-output-hk/hermes.git",
+    "https://github.com/input-output-hk/catalyst-pallas.git"
 ]
 
 [sources.allow-org]

--- a/utilities/dbviz/deny.toml
+++ b/utilities/dbviz/deny.toml
@@ -270,7 +270,8 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/input-output-hk/hermes.git"
+    "https://github.com/input-output-hk/hermes.git",
+    "https://github.com/input-output-hk/catalyst-pallas.git"
 ]
 
 [sources.allow-org]


### PR DESCRIPTION
# Description

Updated `deny.toml` file, allowed "https://github.com/input-output-hk/catalyst-pallas.git" repo.
Needed for https://github.com/input-output-hk/hermes/pull/189