### PR TITLE
fix: Remove duplicated `wasm-tools` tool installation

### DIFF
--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -84,7 +84,6 @@ rust-base:
     RUN cargo install cargo-depgraph --version=1.6.0
     RUN cargo install cargo-llvm-cov --version=0.6.8
     RUN cargo install wasm-tools --version=1.201.0
-    RUN cargo install wasm-tools --version=1.201.0
     RUN cargo install cargo-expand --version=1.0.79
     RUN cargo install wit-bindgen-cli --version=0.22.0
     RUN cargo install --git https://github.com/bytecodealliance/wasmtime --tag v17.0.0 verify-component-adapter


### PR DESCRIPTION
# Description

Removed `wasm-tools` duplicate installation