### PR TITLE
fix: Fix  Rust builder tooling

### DIFF
--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -27,7 +27,7 @@ rust-base:
     # A potential bug was found inside `libgcc:13` version.
     # It works fine with the `libgcc:12` version.
     # Look: https://github.com/bytecodealliance/wasmtime/issues/7997
-    FROM rust:1.75-alpine3.18
+    FROM rust:1.75-alpine3.19
 
     RUN echo "TARGETPLATFORM = $TARGETPLATFORM"; \
         echo "TARGETOS       = $TARGETOS"; \
@@ -75,18 +75,18 @@ rust-base:
     # Install tools we use commonly with `cargo`.
     # Note, we disable static compiles for tools, specifically, as its not required.
     # These tools are not artifacts and we do not use them in production.
-    RUN cargo install cargo-nextest --version=0.9.68
-    RUN cargo install cargo-machete --version=0.6.1
-    RUN cargo install refinery_cli  --version=0.8.13
+    RUN cargo install cargo-nextest --version=0.9.68 --locked
+    RUN cargo install cargo-machete --version=0.6.1 --locked
+    RUN cargo install refinery_cli  --version=0.8.13 --locked
     # TODO: https://github.com/input-output-hk/catalyst-ci/issues/214
-    RUN cargo install cargo-deny    --version=0.14.10
-    RUN cargo install cargo-modules --version=0.14.0
-    RUN cargo install cargo-depgraph --version=1.6.0
-    RUN cargo install cargo-llvm-cov --version=0.6.8
-    RUN cargo install wasm-tools --version=1.201.0
-    RUN cargo install cargo-expand --version=1.0.79
-    RUN cargo install wit-bindgen-cli --version=0.24.0
-    RUN cargo install --git https://github.com/bytecodealliance/wasmtime --tag v17.0.0 verify-component-adapter
+    RUN cargo install cargo-deny    --version=0.14.10 --locked
+    RUN cargo install cargo-modules --version=0.14.0 --locked
+    RUN cargo install cargo-depgraph --version=1.6.0 --locked
+    RUN cargo install cargo-llvm-cov --version=0.6.8 --locked
+    RUN cargo install wasm-tools --version=1.201.0 --locked
+    RUN cargo install cargo-expand --version=1.0.79 --locked
+    RUN cargo install wit-bindgen-cli --version=0.24.0 --locked
+    RUN cargo install --git https://github.com/bytecodealliance/wasmtime --tag v17.0.0 verify-component-adapter --locked
 
     SAVE ARTIFACT $CARGO_HOME/bin/refinery refinery
     SAVE ARTIFACT $CARGO_HOME/bin/wasm-tools wasm-tools


### PR DESCRIPTION
# Description

Add a `--locked` flag to all rust builder tooling installation, to eliminate an issue of unexpected usage of broken libs by to the tolling