### PR TITLE
feat: Add hdf5 git repo to deny allow list

### DIFF
--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -70,7 +70,8 @@ allow = [
     "BSD-2-Clause",
     "BlueOak-1.0.0",
     "Apache-2.0 WITH LLVM-exception",
-    "CC0-1.0"
+    "CC0-1.0",
+    "ISC",
 ]
 exceptions = [
     #{ allow = ["Zlib"], crate = "tinyvec" },

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -52,7 +52,8 @@ unknown-git = "deny"
 allow-git = [
     "https://github.com/input-output-hk/hermes.git",
     "https://github.com/input-output-hk/catalyst-pallas.git",
-    "https://github.com/bytecodealliance/wasmtime"
+    "https://github.com/bytecodealliance/wasmtime",
+    "https://github.com/aldanor/hdf5-rust",
 ]
 
 [licenses]

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -70,7 +70,8 @@ allow = [
     "BSD-2-Clause",
     "BlueOak-1.0.0",
     "Apache-2.0 WITH LLVM-exception",
-    "CC0-1.0"
+    "CC0-1.0",
+    "ISC",
 ]
 exceptions = [
     #{ allow = ["Zlib"], crate = "tinyvec" },

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -52,7 +52,8 @@ unknown-git = "deny"
 allow-git = [
     "https://github.com/input-output-hk/hermes.git",
     "https://github.com/input-output-hk/catalyst-pallas.git",
-    "https://github.com/bytecodealliance/wasmtime"
+    "https://github.com/bytecodealliance/wasmtime",
+    "https://github.com/aldanor/hdf5-rust",
 ]
 
 [licenses]

--- a/utilities/dbviz/deny.toml
+++ b/utilities/dbviz/deny.toml
@@ -70,7 +70,8 @@ allow = [
     "BSD-2-Clause",
     "BlueOak-1.0.0",
     "Apache-2.0 WITH LLVM-exception",
-    "CC0-1.0"
+    "CC0-1.0",
+    "ISC",
 ]
 exceptions = [
     #{ allow = ["Zlib"], crate = "tinyvec" },

--- a/utilities/dbviz/deny.toml
+++ b/utilities/dbviz/deny.toml
@@ -52,7 +52,8 @@ unknown-git = "deny"
 allow-git = [
     "https://github.com/input-output-hk/hermes.git",
     "https://github.com/input-output-hk/catalyst-pallas.git",
-    "https://github.com/bytecodealliance/wasmtime"
+    "https://github.com/bytecodealliance/wasmtime",
+    "https://github.com/aldanor/hdf5-rust",
 ]
 
 [licenses]


### PR DESCRIPTION
# Description

- Added https://github.com/aldanor/hdf5-rust repo to the deny.toml allowance list.
- Added new license `ISC` needed with the dep of the hdf5  https://github.com/nagisa/rust_libloading

Needed for https://github.com/input-output-hk/hermes/pull/238