### PR TITLE
feat: Update Rust builder with hdf5 needed tools, update deny.toml files

### DIFF
--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -55,7 +55,7 @@ rust-base:
             pkgconfig \
             openssl-dev \
             openssl-libs-static \
-            hdf5
+            cmake
 
     # Fix up font cache.
     RUN fc-cache -f

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -54,7 +54,8 @@ rust-base:
             findutils \
             pkgconfig \
             openssl-dev \
-            openssl-libs-static
+            openssl-libs-static \
+            hdf5
 
     # Fix up font cache.
     RUN fc-cache -f

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -39,7 +39,7 @@ rust-base:
     # Note: openssl-dev and openssl-libs-static are added to support the cargo-component crate.
     #       if that crate is removed, these dependencies can also be removed.
     RUN apk add --no-cache \
-            musl-dev \
+            build-base \
             mold \
             clang \
             py3-pip \

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -84,6 +84,11 @@ crate = "byte-array-literals"
 expression = "Apache-2.0 WITH LLVM-exception"
 license-files = [{ path = "../../../LICENSE", hash = 0x001c7e6c }]
 
+[[licenses.clarify]]
+crate = "hdf5-src"
+expression = "MIT"
+license-files = [{ path = "../LICENSE-MIT", hash = 0x001c7e6c }]
+
 # SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
 # https://spdx.org/licenses/OpenSSL.html
 # ISC - Both BoringSSL and ring use this for their new files

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -84,6 +84,11 @@ crate = "byte-array-literals"
 expression = "Apache-2.0 WITH LLVM-exception"
 license-files = [{ path = "../../../LICENSE", hash = 0x001c7e6c }]
 
+[[licenses.clarify]]
+crate = "hdf5-src"
+expression = "MIT"
+license-files = [{ path = "../LICENSE-MIT", hash = 0x001c7e6c }]
+
 # SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
 # https://spdx.org/licenses/OpenSSL.html
 # ISC - Both BoringSSL and ring use this for their new files

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -84,6 +84,9 @@ crate = "byte-array-literals"
 expression = "Apache-2.0 WITH LLVM-exception"
 license-files = [{ path = "../../../LICENSE", hash = 0x001c7e6c }]
 
+crate = "hdf5-src"
+expression = "MIT"
+
 # SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
 # https://spdx.org/licenses/OpenSSL.html
 # ISC - Both BoringSSL and ring use this for their new files

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -84,9 +84,6 @@ crate = "byte-array-literals"
 expression = "Apache-2.0 WITH LLVM-exception"
 license-files = [{ path = "../../../LICENSE", hash = 0x001c7e6c }]
 
-crate = "hdf5-src"
-expression = "MIT"
-
 # SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
 # https://spdx.org/licenses/OpenSSL.html
 # ISC - Both BoringSSL and ring use this for their new files

--- a/utilities/dbviz/deny.toml
+++ b/utilities/dbviz/deny.toml
@@ -84,6 +84,11 @@ crate = "byte-array-literals"
 expression = "Apache-2.0 WITH LLVM-exception"
 license-files = [{ path = "../../../LICENSE", hash = 0x001c7e6c }]
 
+[[licenses.clarify]]
+crate = "hdf5-src"
+expression = "MIT"
+license-files = [{ path = "../LICENSE-MIT", hash = 0x001c7e6c }]
+
 # SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
 # https://spdx.org/licenses/OpenSSL.html
 # ISC - Both BoringSSL and ring use this for their new files


### PR DESCRIPTION
# Description

- Added necessary tooling for static compilation of `hdf5` lib.
- Update `deny.toml` files to fix licence issues with `hdf5` crate.

Needed for https://github.com/input-output-hk/hermes/pull/239