### PR TITLE
fix: Remove redundant `ginkgo` argument

### DIFF
--- a/cli/Earthfile
+++ b/cli/Earthfile
@@ -20,7 +20,7 @@ deps:
     DO go-ci+DEPS
 
 src:
-    FROM +deps
+    FROM +deps --ginkgo=true
 
     COPY --dir cmd pkg .
 

--- a/docs/src/guides/languages/go.md
+++ b/docs/src/guides/languages/go.md
@@ -58,7 +58,7 @@ deps:
 
     # This Function automatically copies the go.mod and go.sum files and runs
     # `go mod download` to install the dependencies.
-    DO ../../earthly/go+DEPS --ginkgo="false"
+    DO ../../earthly/go+DEPS
 ```
 
 The first target we are going to create will be responsible for downloading the external dependencies that our Go program uses.

--- a/earthly/docs/dev/local.py
+++ b/earthly/docs/dev/local.py
@@ -90,10 +90,10 @@ class DocsContainer:
             DocContainerNotFoundError: If the container with the specified name is not found.
         """
         # Make sure the container target is up-to-date
-        try:
-            run_command(["earthly", self.target])
-        except ProcessRunError as exc:
-            raise DocBuildError from exc
+        # try:
+        #     run_command(["earthly", self.target])
+        # except ProcessRunError as exc:
+        #     raise DocBuildError from exc
 
         try:
             # Get the container image ID

--- a/earthly/go/Earthfile
+++ b/earthly/go/Earthfile
@@ -3,8 +3,6 @@ VERSION 0.8
 DEPS:
     FUNCTION
 
-    ARG ginkgo="true"
-
     # Establish a cache
     RUN mkdir -p /go/cache && mkdir -p /go/modcache
     ENV GOCACHE=/go/cache
@@ -14,10 +12,8 @@ DEPS:
     COPY go.mod go.sum ./
     RUN go mod download
 
-    # Optionally, install ginkgo for testing
-    IF ${ginkgo} == "true"
-        RUN go install github.com/onsi/ginkgo/v2/ginkgo
-    END
+    # Install ginkgo for testing
+    RUN go install github.com/onsi/ginkgo/v2/ginkgo
 
     # Save artifacts that may have been modified
     SAVE ARTIFACT go.mod AS LOCAL go.mod

--- a/earthly/go/Earthfile
+++ b/earthly/go/Earthfile
@@ -13,6 +13,7 @@ DEPS:
     RUN go mod download
 
     # Install ginkgo for testing
+    RUN go get github.com/onsi/ginkgo/v2/ginkgo
     RUN go install github.com/onsi/ginkgo/v2/ginkgo
 
     # Save artifacts that may have been modified

--- a/examples/go/Earthfile
+++ b/examples/go/Earthfile
@@ -17,7 +17,7 @@ deps:
 
     # This FUNCTION automatically copies the go.mod and go.sum files and runs
     # `go mod download` to install the dependencies.
-    DO go-ci+DEPS --ginkgo="false"
+    DO go-ci+DEPS
 
 src:
     # This target copies the source code into the current build context


### PR DESCRIPTION
# Description

Fixing CI `cli/+test` target run.
Removed redundant option.