### PR TITLE
feat: Modify rust clippy lints

### DIFF
--- a/earthly/rust/stdcfgs/cargo_manifest/project.toml
+++ b/earthly/rust/stdcfgs/cargo_manifest/project.toml
@@ -22,6 +22,8 @@ unescaped_backticks = "deny"
 pedantic = { level = "deny", priority = -1 }
 unwrap_used = "deny"
 expect_used = "deny"
+todo = "deny"
+unimplemented = "deny"
 exit = "deny"
 get_unwrap = "deny"
 index_refutable_slice = "deny"

--- a/earthly/rust/stdcfgs/cargo_manifest/workspace.toml
+++ b/earthly/rust/stdcfgs/cargo_manifest/workspace.toml
@@ -22,6 +22,8 @@ unescaped_backticks = "deny"
 pedantic = { level = "deny", priority = -1 }
 unwrap_used = "deny"
 expect_used = "deny"
+todo = "deny"
+unimplemented = "deny"
 exit = "deny"
 get_unwrap = "deny"
 index_refutable_slice = "deny"

--- a/earthly/rust/stdcfgs/clippy.toml
+++ b/earthly/rust/stdcfgs/clippy.toml
@@ -1,1 +1,1 @@
-allow-expect-in-tests = true
+allow-unwrap-in-tests = true

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -31,6 +31,8 @@ unescaped_backticks = "deny"
 pedantic = { level = "deny", priority = -1 }
 unwrap_used = "deny"
 expect_used = "deny"
+todo = "deny"
+unimplemented = "deny"
 exit = "deny"
 get_unwrap = "deny"
 index_refutable_slice = "deny"

--- a/examples/rust/clippy.toml
+++ b/examples/rust/clippy.toml
@@ -1,1 +1,1 @@
-allow-expect-in-tests = true
+allow-unwrap-in-tests = true

--- a/utilities/dbviz/Cargo.toml
+++ b/utilities/dbviz/Cargo.toml
@@ -26,6 +26,8 @@ unescaped_backticks = "deny"
 pedantic = { level = "deny", priority = -1 }
 unwrap_used = "deny"
 expect_used = "deny"
+todo = "deny"
+unimplemented = "deny"
 exit = "deny"
 get_unwrap = "deny"
 index_refutable_slice = "deny"

--- a/utilities/dbviz/clippy.toml
+++ b/utilities/dbviz/clippy.toml
@@ -1,1 +1,1 @@
-allow-expect-in-tests = true
+allow-unwrap-in-tests = true


### PR DESCRIPTION
# Description

Updated rust clippy lints definitions:
- allowed to `unwrap` in tests.
- added new lint `todo = "deny`
- added new lint `unimplemented = "deny`