### PR TITLE
feat: Rust clippy  option `allow-expect-in-tests = true` 

### DIFF
--- a/earthly/rust/stdcfgs/clippy.toml
+++ b/earthly/rust/stdcfgs/clippy.toml
@@ -1,1 +1,2 @@
 allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/examples/rust/clippy.toml
+++ b/examples/rust/clippy.toml
@@ -1,1 +1,2 @@
 allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/utilities/dbviz/clippy.toml
+++ b/utilities/dbviz/clippy.toml
@@ -1,1 +1,2 @@
 allow-unwrap-in-tests = true
+allow-expect-in-tests = true


### PR DESCRIPTION
# Description

Added rust clippy  option `allow-expect-in-tests = true` 

needed for https://github.com/input-output-hk/hermes/pull/323