### PR TITLE
feat: Enables rust backtrace for earthly rust builder

### DIFF
--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -34,7 +34,7 @@ rust-base:
     WORKDIR /root
 
     # Enables rust backtrace when something panics
-    ENV RUST_BACKTRACE=1
+    ENV RUST_BACKTRACE=full
 
     # Install necessary packages
     # Expand this list as needed, rather than adding more tools in later containers.

--- a/earthly/rust/Earthfile
+++ b/earthly/rust/Earthfile
@@ -33,6 +33,9 @@ rust-base:
 
     WORKDIR /root
 
+    # Enables rust backtrace when something panics
+    ENV RUST_BACKTRACE=1
+
     # Install necessary packages
     # Expand this list as needed, rather than adding more tools in later containers.
     #

--- a/examples/rust/crates/foo/src/lib.rs
+++ b/examples/rust/crates/foo/src/lib.rs
@@ -11,15 +11,6 @@ pub fn fmt_hello(name: &str, count: u8) -> String {
 mod tests {
     use super::*;
 
-    fn return_error() -> Result<(), String> {
-        Err("Some random error".to_string())
-    }
-
-    #[test]
-    fn test_return_error() {
-        return_error().unwrap();
-    }
-
     #[test]
     /// Prove we can say hello to Dave on a 3 count.
     fn test_hello_dave_3() {

--- a/examples/rust/crates/foo/src/lib.rs
+++ b/examples/rust/crates/foo/src/lib.rs
@@ -11,6 +11,15 @@ pub fn fmt_hello(name: &str, count: u8) -> String {
 mod tests {
     use super::*;
 
+    fn return_error() -> Result<(), String> {
+        Err("Some random error".to_string())
+    }
+
+    #[test]
+    fn test_return_error() {
+        return_error().unwrap();
+    }
+
     #[test]
     /// Prove we can say hello to Dave on a 3 count.
     fn test_hello_dave_3() {


### PR DESCRIPTION
# Description

Enabled Rust backtrace when something panics.
Setting up `RUST_BACKTRACE` env var inside `rust-base`.

## Related Pull Requests

https://github.com/input-output-hk/hermes/pull/323