### PR TITLE
feat(cat-ci): Add GITHUB_TOKEN as a secret when earthly is invoked.

### DIFF
--- a/actions/build/action.yml
+++ b/actions/build/action.yml
@@ -35,6 +35,11 @@ inputs:
     description: Additional flags to pass to the Earthly target
     required: false
     default: ""
+  github_token:
+    description: Github token used to login to the Github API (defaults to runner token)
+    required: false
+    default: ${{ github.token }}
+    
 
 runs:
   using: composite
@@ -51,6 +56,10 @@ runs:
 
           if [[ -n "${{ inputs.earthly_satellite}}" ]]; then
             EARTHLY_FLAGS+=("--buildkit-host" "tcp://${{ inputs.earthly_satellite }}:8372")
+          fi
+
+          if [[ -n "${{ inputs.github_token}}" ]]; then
+            EARTHLY_FLAGS+=("--secret" "GITHUB_TOKEN=${{ inputs.github_token }}")
           fi
 
           if [[ "${{ inputs.publish }}" == "true" ]]; then


### PR DESCRIPTION
# Description

Causes GITHUB_TOKEN to be supplied to earthly so it can be used by targets, as a secret.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
