### PR TITLE
feat: Enable LaTex mathematical equations format for MkDocs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 INHERIT: std-theme.yml
 
-# cspell: words fontawesome
+# cspell: words fontawesome mathjax
 
 # Project Information
 site_name: Project Catalyst - CI Documentation

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 INHERIT: std-theme.yml
 
-# cspell: words fontawesome mathjax
+# cspell: words fontawesome
 
 # Project Information
 site_name: Project Catalyst - CI Documentation

--- a/docs/src/appendix/examples/latex.md
+++ b/docs/src/appendix/examples/latex.md
@@ -1,10 +1,10 @@
 ---
-icon: material/functions
+icon: $\LaTeX{}$
 ---
 
 <!-- cspell: words infty -->
 
-# LaTex
+# LaTex formulas
 
 Simple formula as a separate block:
 \begin{equation}

--- a/docs/src/appendix/examples/latex.md
+++ b/docs/src/appendix/examples/latex.md
@@ -1,0 +1,30 @@
+---
+icon: material/functions
+---
+
+# LaTex
+
+Simple formula as a separate block:
+\begin{equation}
+5 = 2 + 3
+\end{equation}
+
+Simple formula inside the sentence: $5 = 2 + 3$.
+
+More complex examples:
+
+\begin{equation}
+e^{ix} = cox(x) + i sin(x)
+\end{equation}
+
+\begin{equation}
+cos(x) = \frac{e^{ix} + e^{-ix}}{2}
+\end{equation}
+
+\begin{equation}
+sin(x) = \frac{e^{ix} - e^{-ix}}{2i}
+\end{equation}
+
+\begin{equation}
+f(x) = \frac{a_0}{2} + \sum_{n=1}^{\infty} (a_n cos(nx) + b_n sin(nx))
+\end{equation}

--- a/docs/src/appendix/examples/latex.md
+++ b/docs/src/appendix/examples/latex.md
@@ -1,7 +1,3 @@
----
-icon: $\LaTeX{}$
----
-
 <!-- cspell: words infty -->
 
 # LaTex formulas

--- a/docs/src/appendix/examples/latex.md
+++ b/docs/src/appendix/examples/latex.md
@@ -2,6 +2,8 @@
 icon: material/functions
 ---
 
+<!-- cspell: words infty -->
+
 # LaTex
 
 Simple formula as a separate block:

--- a/earthly/docs/common/javascript/mathjax.js
+++ b/earthly/docs/common/javascript/mathjax.js
@@ -1,3 +1,5 @@
+// cspell: words arithmatex
+
 window.MathJax = {
     tex: {
       inlineMath: [ ["\\(","\\)"] ],

--- a/earthly/docs/common/javascript/mathjax.js
+++ b/earthly/docs/common/javascript/mathjax.js
@@ -1,0 +1,19 @@
+window.MathJax = {
+    tex: {
+      inlineMath: [ ["\\(","\\)"] ],
+      displayMath: [ ["\\[","\\]"] ],
+      processEscapes: true,
+      processEnvironments: true
+    },
+    options: {
+      ignoreHtmlClass: ".*",
+      processHtmlClass: "arithmatex"
+    }
+  };
+
+document$.subscribe(() => { 
+    MathJax.startup.output.clearCache()
+    MathJax.typesetClear()
+    MathJax.texReset()
+    MathJax.typesetPromise()
+})

--- a/earthly/docs/common/std-theme.yml
+++ b/earthly/docs/common/std-theme.yml
@@ -118,4 +118,6 @@ extra:
 
 extra_javascript:
   - javascript/massillia-graphviz.js
+  - javascript/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
     

--- a/earthly/docs/common/std-theme.yml
+++ b/earthly/docs/common/std-theme.yml
@@ -1,7 +1,7 @@
 # cspell: words Diagramsnet, pymdownx, linenums, inlinehilite, superfences,
 # cspell: words tasklist, betterem, materialx, twemoji, smartsymbols,
 # cspell: words kroki, excalidraw, glightbox, cips, pygments, arithmatex, fontawesome
-# cspell: words massillia
+# cspell: words massillia, mathjax
 
 site_author: The Project Catalyst Team
 copyright: (c) 2023 Input Output Global Ltd.


### PR DESCRIPTION
# Description

Allowing [LaTex](https://www.latex-project.org) mathematical equations formatting for MkDocs pages.
Inside `.md` files it is possible to use some of the LaTex entities to nicely represent math equations like this
```Latex
\begin{equation}
  f = \frac{1}{2}
\end{equation}
```
will be shown as 
<img width="162" alt="Screenshot 2024-09-06 at 14 24 16" src="https://github.com/user-attachments/assets/28db7ef2-c16b-4a40-a5c6-811dbdd78e8b">

docs example [section](https://input-output-hk.github.io/catalyst-ci/branch/feat_docs_latex/appendix/examples/latex/)
