### PR TITLE
fix(cat-ci): Pin alpine versions to try and stop containers disappearing on upstream updates

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -29,7 +29,7 @@ check-spelling:
 
 # check-bash - test all bash files lint properly according to shellcheck.
 check-bash:
-    FROM alpine:3.20
+    FROM alpine:3.20.3
 
     DO bash-ci+SHELLCHECK --src=.
 

--- a/docs/src/appendix/earthly.md
+++ b/docs/src/appendix/earthly.md
@@ -184,7 +184,7 @@ build:
 
 docker:
     # Here we inherit from a "fresh" minimal alpine version
-    FROM alpine:3.20
+    FROM alpine:3.20.3
     WORKDIR /app
 
     # By default, we'll output this image with the 'latest' tag, but this can be

--- a/docs/src/guides/languages/bash.md
+++ b/docs/src/guides/languages/bash.md
@@ -40,13 +40,13 @@ All that needs to happen is the following be added to the `Earthfile` in the roo
 ```Earthfile
 # Internal: shell-check - test all bash files against our shell check rules.
 shell-check:
-    FROM alpine:3.20
+    FROM alpine:3.20.3
 
     DO github.com/input-output-hk/catalyst-ci/earthly/bash:vx.y.z+SHELLCHECK --src=.
 
 # check all repo wide checks are run from here
 check:
-    FROM alpine:3.20
+    FROM alpine:3.20.3
 
     # Lint all bash files.
     BUILD +shell-check

--- a/docs/src/guides/languages/go.md
+++ b/docs/src/guides/languages/go.md
@@ -193,7 +193,7 @@ publish-example:
     # This target is called by CI when publishing images. It should use the
     # `SAVE IMAGE` command to save the image which is then picked up by the CI.
     # Note that we start from a "fresh" base image.
-    FROM alpine:3.20
+    FROM alpine:3.20.3
     WORKDIR /app
     ARG tag=latest  # Prefer to use `latest` by default, the CI will override this.
 

--- a/earthly/bash/Earthfile
+++ b/earthly/bash/Earthfile
@@ -4,7 +4,7 @@ IMPORT ../../utilities/scripts AS scripts
 
 # Internal: builder creates a container we can use to execute shellcheck
 builder:
-    FROM alpine:3.20
+    FROM alpine:3.20.3
 
     RUN apk add --no-cache \
         bash \

--- a/earthly/docs/Earthfile
+++ b/earthly/docs/Earthfile
@@ -104,7 +104,7 @@ PACKAGE:
     FUNCTION
 
     # Use the official Nginx base image
-    FROM nginx:alpine3.18-slim
+    FROM nginx:alpine3.20-slim
 
     # Force this server to disable the browsers cache for these files.
     RUN echo " " > /etc/nginx/conf.d/disable-cache.conf; \

--- a/earthly/postgresql/Earthfile
+++ b/earthly/postgresql/Earthfile
@@ -134,7 +134,7 @@ FORMAT:
 
 # Internal: Integration Test container image
 integration-test:
-    FROM earthly/dind:alpine-3.18-docker-23.0.6-r7
+    FROM earthly/dind:alpine-3.20-docker-26.1.5-r0
 
     RUN apk add --no-cache \
             bash \

--- a/examples/go/Earthfile
+++ b/examples/go/Earthfile
@@ -69,7 +69,7 @@ publish-example:
     # This target is called by CI when publishing images. It should use the
     # `SAVE IMAGE` command to save the image which is then picked up by the CI.
     # Note that we start from a "fresh" base image.
-    FROM alpine:3.20
+    FROM alpine:3.20.3
     WORKDIR /app
     ARG tag=latest  # Prefer to use `latest` by default, the CI will override this.
 


### PR DESCRIPTION
Fix for CI broken by upstream Alpine containers disappearing