### PR TITLE
fix(earthly-flutter): Make sure earthly target fails when flutter tests fail

### DIFF
--- a/earthly/flutter/Earthfile
+++ b/earthly/flutter/Earthfile
@@ -146,7 +146,13 @@ UNIT_TESTS:
 
         # We always want to save the test_reports and coverage
         # therefore we must defer the error reported here until later.
-        RUN melos run test-report || touch fail
+        RUN melos run test-report > melos-output.txt 2>&1 || touch fail
+
+        # If not failed then print the output immediately,
+        # if it has failed then it's printed at the end of the function when exiting.
+        IF [ ! -f fail ]
+            RUN cat melos-output.txt
+        END
 
         WAIT
             SAVE ARTIFACT test_reports AS LOCAL test_reports
@@ -155,8 +161,9 @@ UNIT_TESTS:
 
         # Defer the failure to here.
         IF [ -f fail ]
-            RUN echo "Error occurred when running: melos run test-report"
-            RUN exit 1
+            RUN echo "Error occurred when running: melos run test-report"; \
+                cat melos-output.txt; \
+                exit 1
         END
     ELSE
         RUN echo "Running flutter test"

--- a/earthly/flutter/Earthfile
+++ b/earthly/flutter/Earthfile
@@ -143,18 +143,24 @@ UNIT_TESTS:
 
     IF [ -f melos.yaml ]
         RUN echo "Running unit tests with melos."
-        RUN melos run test-report
+
+        # We always want to save the test_reports and coverage
+        # therefore we must defer the error reported here until later.
+        RUN melos run test-report || touch fail
 
         WAIT
             SAVE ARTIFACT test_reports AS LOCAL test_reports
             SAVE ARTIFACT coverage AS LOCAL coverage
         END
+
+        # Defer the failure to here.
+        IF [ -f fail ]
+            RUN echo "Error occurred when running: melos run test-report"
+            RUN exit 1
+        END
     ELSE
         RUN echo "Running flutter test"
         RUN flutter test
-        WAIT
-            SAVE ARTIFACT test_reports AS LOCAL test_reports
-        END
     END
 
 # Build web app and save artifacts locally if needed.


### PR DESCRIPTION
# Description

Defers the error that can be raised after running flutter unit tests until the test_reports and coverage artifacts are saved, then raises an error to indicate that the target failed.

- `flutter test` does not generate any test_reports therefore I'm removing the artifacts

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
