### PR TITLE
fix: add ruleset for linting OpenAPI

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -11,6 +11,20 @@ extends:
 - 'https://unpkg.com/@stoplight/spectral-documentation@1.3.1/dist/ruleset.mjs'
 - 'https://unpkg.com/@stoplight/spectral-owasp-ruleset@1.4.3/dist/ruleset.mjs'
 
+formats: ["oas3", "json-schema-2020-12"]
+
+rules: 
+  api-path:
+    message: "Invalid API path - should be /api/draft/* or /api/v<number>/*"
+    given: "$.paths"
+    severity: error
+    then:
+      field: "@key"
+      function: pattern
+      functionOptions:
+        # Match paths that start with /api/draft/* or /api/v<number>/*
+        match: "^/api/(draft|v\\d+)/.*$"
+
 # Ignoring rules example
 # rules:
 #   docs-tags: off

--- a/examples/openapi/example.json
+++ b/examples/openapi/example.json
@@ -23,7 +23,7 @@
 		}
 	],
 	"paths": {
-		"/users": {
+		"/api/v1/users": {
 			"get": {
 				"tags": ["user"],
 				"operationId": "getUsers",


### PR DESCRIPTION
# Description

Add ruleset in Spectral for linting OpenAPI

## Related Issue(s)

Closes 

## Description of Changes

- Create a ruleset for checking OpenAPI spec API path
- The API path should match either  `/api/draft/* or /api/v<number>/*`
- Modify the example to suite the use case

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
