### PR TITLE
feat(rust): Update disable running benchmarks with `nextest` and `llvm-cov`

### DIFF
--- a/earthly/rust/scripts/std_build.py
+++ b/earthly/rust/scripts/std_build.py
@@ -87,7 +87,7 @@ def cargo_llvm_cov(
 
 def cargo_bench(flags: str, verbose: bool = False) -> exec_manager.Result:
     return exec_manager.cli_run(
-        "cargo bench " + f"{flags} ",
+        "cargo bench --all-targets --no-fail-fast" + f"{flags} ",
         name="Benchmarks all run to completion check",
         verbose=verbose,
     )

--- a/earthly/rust/stdcfgs/cargo_config.toml
+++ b/earthly/rust/stdcfgs/cargo_config.toml
@@ -80,7 +80,6 @@ docs = "doc --release --no-deps --document-private-items --bins --lib --examples
 testunit = "nextest run --release --bins --lib --tests --no-fail-fast -P ci"
 testcov = "llvm-cov nextest --release --bins --lib --tests --no-fail-fast -P ci"
 testdocs = "test --doc --release"
-benches = "bench --all-targets --no-fail-fast"
 
 # Rust formatting, MUST be run with +nightly
 fmtchk = "fmt -- --check -v --color=always"

--- a/earthly/rust/stdcfgs/cargo_config.toml
+++ b/earthly/rust/stdcfgs/cargo_config.toml
@@ -77,9 +77,10 @@ lint-vscode = "clippy --message-format=json-diagnostic-rendered-ansi --all-targe
 
 docs = "doc --release --no-deps --document-private-items --bins --lib --examples"
 # nightly docs build broken... when they are'nt we can enable these docs... --unit-graph --timings=html,json -Z unstable-options"
-testunit = "nextest run --release --bins --lib --tests --benches --no-fail-fast -P ci"
-testcov = "llvm-cov nextest --release --bins --lib --tests --benches --no-fail-fast -P ci"
+testunit = "nextest run --release --bins --lib --tests --no-fail-fast -P ci"
+testcov = "llvm-cov nextest --release --bins --lib --tests --no-fail-fast -P ci"
 testdocs = "test --doc --release"
+benches = "bench --all-targets --no-fail-fast"
 
 # Rust formatting, MUST be run with +nightly
 fmtchk = "fmt -- --check -v --color=always"

--- a/examples/rust/.cargo/config.toml
+++ b/examples/rust/.cargo/config.toml
@@ -80,7 +80,6 @@ docs = "doc --release --no-deps --document-private-items --bins --lib --examples
 testunit = "nextest run --release --bins --lib --tests --no-fail-fast -P ci"
 testcov = "llvm-cov nextest --release --bins --lib --tests --no-fail-fast -P ci"
 testdocs = "test --doc --release"
-benches = "bench --all-targets --no-fail-fast"
 
 # Rust formatting, MUST be run with +nightly
 fmtchk = "fmt -- --check -v --color=always"

--- a/examples/rust/.cargo/config.toml
+++ b/examples/rust/.cargo/config.toml
@@ -77,9 +77,10 @@ lint-vscode = "clippy --message-format=json-diagnostic-rendered-ansi --all-targe
 
 docs = "doc --release --no-deps --document-private-items --bins --lib --examples"
 # nightly docs build broken... when they are'nt we can enable these docs... --unit-graph --timings=html,json -Z unstable-options"
-testunit = "nextest run --release --bins --lib --tests --benches --no-fail-fast -P ci"
-testcov = "llvm-cov nextest --release --bins --lib --tests --benches --no-fail-fast -P ci"
+testunit = "nextest run --release --bins --lib --tests --no-fail-fast -P ci"
+testcov = "llvm-cov nextest --release --bins --lib --tests --no-fail-fast -P ci"
 testdocs = "test --doc --release"
+benches = "bench --all-targets --no-fail-fast"
 
 # Rust formatting, MUST be run with +nightly
 fmtchk = "fmt -- --check -v --color=always"

--- a/examples/rust/crates/foo/benches/benchmark.rs
+++ b/examples/rust/crates/foo/benches/benchmark.rs
@@ -1,11 +1,6 @@
 //! Simple benchmark example
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-#[test]
-fn test_fibonacci() {
-    assert_eq!(fibonacci(20), 6765);
-}
-
 /// fibonacci calculates the nth fibonacci number
 fn fibonacci(n: u64) -> u64 {
     match n {


### PR DESCRIPTION
# Description

Updated our cargo aliases `testunit` and `testcov` by disabling running benchmarks in these runs.
Added additional flags as `--all-targets` and `--no-fail-fast` for `cargo_bench` function.

## Related Issue(s)

Related PR https://github.com/input-output-hk/catalyst-libs/pull/65
