### PR TITLE
feat(rust): Update `cargo deny` check and deny.toml config

### DIFF
--- a/earthly/docs/dev/local.py
+++ b/earthly/docs/dev/local.py
@@ -90,10 +90,10 @@ class DocsContainer:
             DocContainerNotFoundError: If the container with the specified name is not found.
         """
         # Make sure the container target is up-to-date
-        # try:
-        #     run_command(["earthly", self.target])
-        # except ProcessRunError as exc:
-        #     raise DocBuildError from exc
+        try:
+            run_command(["earthly", self.target])
+        except ProcessRunError as exc:
+            raise DocBuildError from exc
 
         try:
             # Get the container image ID

--- a/earthly/docs/dev/local.py
+++ b/earthly/docs/dev/local.py
@@ -90,10 +90,10 @@ class DocsContainer:
             DocContainerNotFoundError: If the container with the specified name is not found.
         """
         # Make sure the container target is up-to-date
-        try:
-            run_command(["earthly", self.target])
-        except ProcessRunError as exc:
-            raise DocBuildError from exc
+        # try:
+        #     run_command(["earthly", self.target])
+        # except ProcessRunError as exc:
+        #     raise DocBuildError from exc
 
         try:
             # Get the container image ID

--- a/earthly/rust/scripts/std_checks.py
+++ b/earthly/rust/scripts/std_checks.py
@@ -90,7 +90,7 @@ def main():
     results.add(
         vendor_files_check.toml_diff_check("/stdcfgs/clippy.toml", "clippy.toml")
     )
-    results.add(vendor_files_check.toml_diff_check("/stdcfgs/deny.toml", "deny.toml"))
+    results.add(vendor_files_check.toml_diff_check("/stdcfgs/deny.toml", "deny.toml", strict=False))
 
     # Check if the rust src is properly formatted.
     res = exec_manager.cli_run("cargo +nightly fmtchk ", name="Rust Code Format Check")
@@ -104,7 +104,7 @@ def main():
     results.add(exec_manager.cli_run("cargo machete", name="Unused Dependencies Check"))
     # Check if we have any supply chain issues with dependencies.
     results.add(
-        exec_manager.cli_run("cargo deny check --exclude-dev -W vulnerability", name="Supply Chain Issues Check")
+        exec_manager.cli_run("cargo deny check --exclude-dev", name="Supply Chain Issues Check")
     )
 
     results.print()

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -20,6 +20,21 @@ version = 2
 [bans]
 multiple-versions = "warn"
 wildcards = 'deny'
+deny = [
+    # Scylla DB Drivers currently require OpenSSL.  Its unavoidable.
+    # However, there is movement to enable support for Rustls. 
+    # So, for now, allow open-ssl but it needs to be disabled as soon as Scylla DB enables Rustls.
+    #{ crate = "openssl", use-instead = "rustls" },
+    #{ crate = "openssl-sys", use-instead = "rustls" },
+    "libssh2-sys",
+    # { crate = "git2", use-instead = "gix" },
+    # { crate = "cmake", use-instead = "cc" },
+    # { crate = "windows", reason = "bloated and unnecessary", use-instead = "ideally inline bindings, practically, windows-sys" },
+]
+skip = []
+skip-tree = [
+    { crate = "windows-sys@0.48.0", reason = "a foundational crate for many that bumps far too frequently to ever have a shared version" },
+]
 
 [sources]
 unknown-registry = "deny"

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -1,4 +1,4 @@
-# cspell: words msvc, wasip
+# cspell: words msvc, wasip, rustls, libssh
 
 [graph]
 # cargo-deny is really only ever intended to run on the "normal" tier-1 targets

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -1,4 +1,4 @@
-# cspell: words msvc, wasip, RUSTSEC, rustls, libssh, reqwest, tinyvec, Leay, webpki
+# cspell: words msvc, wasip
 
 [graph]
 # cargo-deny is really only ever intended to run on the "normal" tier-1 targets
@@ -16,49 +16,14 @@ targets = [
 
 [advisories]
 version = 2
-ignore = [
-    { id = "RUSTSEC-2020-0168", reason = "`mach` is used by wasmtime and we have no control over that." },
-    { id = "RUSTSEC-2021-0145", reason = "we don't target windows, and don't use a custom global allocator." },
-    { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is used by crates we rely on, we can't control what they use."},
-]
 
 [bans]
 multiple-versions = "warn"
 wildcards = 'deny'
-deny = [
-    # Scylla DB Drivers currently require OpenSSL.  Its unavoidable.
-    # However, there is movement to enable support for Rustls. 
-    # So, for now, allow open-ssl but it needs to be disabled as soon as Scylla DB enables Rustls.
-    #{ crate = "openssl", use-instead = "rustls" },
-    #{ crate = "openssl-sys", use-instead = "rustls" },
-    "libssh2-sys",
-    # { crate = "git2", use-instead = "gix" },
-    # { crate = "cmake", use-instead = "cc" },
-    # { crate = "windows", reason = "bloated and unnecessary", use-instead = "ideally inline bindings, practically, windows-sys" },
-]
-skip = [
-    # { crate = "bitflags@1.3.2", reason = "https://github.com/seanmonstar/reqwest/pull/2130 should be in the next version" },
-    # { crate = "winnow@0.5.40", reason = "gix 0.59 was yanked, see https://github.com/Byron/gitoxide/issues/1309" },
-    # { crate = "heck@0.4.1", reason = "strum_macros uses this old version" },
-    # { crate = "base64@0.21.7", reason = "gix-transport pulls in this old version, as well as a newer version via reqwest" },
-    # { crate = "byte-array-literalsase64@0.21.7", reason = "gix-transport pulls in this old version, as well as a newer version via reqwest" },
-]
-skip-tree = [
-    { crate = "windows-sys@0.48.0", reason = "a foundational crate for many that bumps far too frequently to ever have a shared version" },
-]
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-
-# List of URLs for allowed Git repositories
-allow-git = [
-    "https://github.com/input-output-hk/catalyst-libs.git",
-    "https://github.com/input-output-hk/catalyst-pallas.git",
-    "https://github.com/input-output-hk/catalyst-mithril.git",
-    "https://github.com/bytecodealliance/wasmtime",
-    "https://github.com/aldanor/hdf5-rust",
-]
 
 [licenses]
 version = 2
@@ -81,44 +46,3 @@ allow = [
     "Zlib",
     "MIT-0",
 ]
-exceptions = [
-    #{ allow = ["Zlib"], crate = "tinyvec" },
-    #{ allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
-    #{ allow = ["OpenSSL"], crate = "ring" },
-]
-
-[[licenses.clarify]]
-crate = "byte-array-literals"
-expression = "Apache-2.0 WITH LLVM-exception"
-license-files = [{ path = "../../../LICENSE", hash = 0x001c7e6c }]
-
-[[licenses.clarify]]
-crate = "hdf5-src"
-expression = "MIT"
-license-files = [{ path = "../LICENSE-MIT", hash = 0x001c7e6c }]
-
-[[licenses.clarify]]
-crate = "ring"
-expression = "MIT"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-
-# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
-# https://spdx.org/licenses/OpenSSL.html
-# ISC - Both BoringSSL and ring use this for their new files
-# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
-# license, for third_party/fiat, which, unlike other third_party directories, is
-# compiled into non-test libraries, is included below."
-# OpenSSL - Obviously
-#expression = "ISC AND MIT AND OpenSSL"
-#license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-
-#[[licenses.clarify]]
-#crate = "webpki"
-#expression = "ISC"
-#license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
-
-# Actually "ISC-style"
-#[[licenses.clarify]]
-#crate = "rustls-webpki"
-#expression = "ISC"
-#license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -1,4 +1,4 @@
-# cspell: words msvc, wasip, rustls, libssh
+# cspell: words msvc, wasip, rustls, libssh, reqwest, tinyvec, Leay, webpki
 
 [graph]
 # cargo-deny is really only ever intended to run on the "normal" tier-1 targets

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -31,7 +31,13 @@ deny = [
     # { crate = "cmake", use-instead = "cc" },
     # { crate = "windows", reason = "bloated and unnecessary", use-instead = "ideally inline bindings, practically, windows-sys" },
 ]
-skip = []
+skip = [
+    # { crate = "bitflags@1.3.2", reason = "https://github.com/seanmonstar/reqwest/pull/2130 should be in the next version" },
+    # { crate = "winnow@0.5.40", reason = "gix 0.59 was yanked, see https://github.com/Byron/gitoxide/issues/1309" },
+    # { crate = "heck@0.4.1", reason = "strum_macros uses this old version" },
+    # { crate = "base64@0.21.7", reason = "gix-transport pulls in this old version, as well as a newer version via reqwest" },
+    # { crate = "byte-array-literalsase64@0.21.7", reason = "gix-transport pulls in this old version, as well as a newer version via reqwest" },
+]
 skip-tree = [
     { crate = "windows-sys@0.48.0", reason = "a foundational crate for many that bumps far too frequently to ever have a shared version" },
 ]
@@ -61,3 +67,44 @@ allow = [
     "Zlib",
     "MIT-0",
 ]
+exceptions = [
+    #{ allow = ["Zlib"], crate = "tinyvec" },
+    #{ allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
+    #{ allow = ["OpenSSL"], crate = "ring" },
+]
+
+[[licenses.clarify]]
+crate = "byte-array-literals"
+expression = "Apache-2.0 WITH LLVM-exception"
+license-files = [{ path = "../../../LICENSE", hash = 0x001c7e6c }]
+
+[[licenses.clarify]]
+crate = "hdf5-src"
+expression = "MIT"
+license-files = [{ path = "../LICENSE-MIT", hash = 0x001c7e6c }]
+
+[[licenses.clarify]]
+crate = "ring"
+expression = "MIT"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+#expression = "ISC AND MIT AND OpenSSL"
+#license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+#[[licenses.clarify]]
+#crate = "webpki"
+#expression = "ISC"
+#license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
+
+# Actually "ISC-style"
+#[[licenses.clarify]]
+#crate = "rustls-webpki"
+#expression = "ISC"
+#license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -20,6 +20,21 @@ version = 2
 [bans]
 multiple-versions = "warn"
 wildcards = 'deny'
+deny = [
+    # Scylla DB Drivers currently require OpenSSL.  Its unavoidable.
+    # However, there is movement to enable support for Rustls. 
+    # So, for now, allow open-ssl but it needs to be disabled as soon as Scylla DB enables Rustls.
+    #{ crate = "openssl", use-instead = "rustls" },
+    #{ crate = "openssl-sys", use-instead = "rustls" },
+    "libssh2-sys",
+    # { crate = "git2", use-instead = "gix" },
+    # { crate = "cmake", use-instead = "cc" },
+    # { crate = "windows", reason = "bloated and unnecessary", use-instead = "ideally inline bindings, practically, windows-sys" },
+]
+skip = []
+skip-tree = [
+    { crate = "windows-sys@0.48.0", reason = "a foundational crate for many that bumps far too frequently to ever have a shared version" },
+]
 
 [sources]
 unknown-registry = "deny"

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -1,4 +1,4 @@
-# cspell: words msvc, wasip
+# cspell: words msvc, wasip, rustls, libssh
 
 [graph]
 # cargo-deny is really only ever intended to run on the "normal" tier-1 targets

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -1,4 +1,4 @@
-# cspell: words msvc, wasip, RUSTSEC, rustls, libssh, reqwest, tinyvec, Leay, webpki
+# cspell: words msvc, wasip
 
 [graph]
 # cargo-deny is really only ever intended to run on the "normal" tier-1 targets
@@ -16,49 +16,14 @@ targets = [
 
 [advisories]
 version = 2
-ignore = [
-    { id = "RUSTSEC-2020-0168", reason = "`mach` is used by wasmtime and we have no control over that." },
-    { id = "RUSTSEC-2021-0145", reason = "we don't target windows, and don't use a custom global allocator." },
-    { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is used by crates we rely on, we can't control what they use."},
-]
 
 [bans]
 multiple-versions = "warn"
 wildcards = 'deny'
-deny = [
-    # Scylla DB Drivers currently require OpenSSL.  Its unavoidable.
-    # However, there is movement to enable support for Rustls. 
-    # So, for now, allow open-ssl but it needs to be disabled as soon as Scylla DB enables Rustls.
-    #{ crate = "openssl", use-instead = "rustls" },
-    #{ crate = "openssl-sys", use-instead = "rustls" },
-    "libssh2-sys",
-    # { crate = "git2", use-instead = "gix" },
-    # { crate = "cmake", use-instead = "cc" },
-    # { crate = "windows", reason = "bloated and unnecessary", use-instead = "ideally inline bindings, practically, windows-sys" },
-]
-skip = [
-    # { crate = "bitflags@1.3.2", reason = "https://github.com/seanmonstar/reqwest/pull/2130 should be in the next version" },
-    # { crate = "winnow@0.5.40", reason = "gix 0.59 was yanked, see https://github.com/Byron/gitoxide/issues/1309" },
-    # { crate = "heck@0.4.1", reason = "strum_macros uses this old version" },
-    # { crate = "base64@0.21.7", reason = "gix-transport pulls in this old version, as well as a newer version via reqwest" },
-    # { crate = "byte-array-literalsase64@0.21.7", reason = "gix-transport pulls in this old version, as well as a newer version via reqwest" },
-]
-skip-tree = [
-    { crate = "windows-sys@0.48.0", reason = "a foundational crate for many that bumps far too frequently to ever have a shared version" },
-]
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-
-# List of URLs for allowed Git repositories
-allow-git = [
-    "https://github.com/input-output-hk/catalyst-libs.git",
-    "https://github.com/input-output-hk/catalyst-pallas.git",
-    "https://github.com/input-output-hk/catalyst-mithril.git",
-    "https://github.com/bytecodealliance/wasmtime",
-    "https://github.com/aldanor/hdf5-rust",
-]
 
 [licenses]
 version = 2
@@ -81,44 +46,3 @@ allow = [
     "Zlib",
     "MIT-0",
 ]
-exceptions = [
-    #{ allow = ["Zlib"], crate = "tinyvec" },
-    #{ allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
-    #{ allow = ["OpenSSL"], crate = "ring" },
-]
-
-[[licenses.clarify]]
-crate = "byte-array-literals"
-expression = "Apache-2.0 WITH LLVM-exception"
-license-files = [{ path = "../../../LICENSE", hash = 0x001c7e6c }]
-
-[[licenses.clarify]]
-crate = "hdf5-src"
-expression = "MIT"
-license-files = [{ path = "../LICENSE-MIT", hash = 0x001c7e6c }]
-
-[[licenses.clarify]]
-crate = "ring"
-expression = "MIT"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-
-# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
-# https://spdx.org/licenses/OpenSSL.html
-# ISC - Both BoringSSL and ring use this for their new files
-# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
-# license, for third_party/fiat, which, unlike other third_party directories, is
-# compiled into non-test libraries, is included below."
-# OpenSSL - Obviously
-#expression = "ISC AND MIT AND OpenSSL"
-#license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-
-#[[licenses.clarify]]
-#crate = "webpki"
-#expression = "ISC"
-#license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
-
-# Actually "ISC-style"
-#[[licenses.clarify]]
-#crate = "rustls-webpki"
-#expression = "ISC"
-#license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -1,4 +1,4 @@
-# cspell: words msvc, wasip, rustls, libssh
+# cspell: words msvc, wasip, rustls, libssh, reqwest, tinyvec, Leay, webpki
 
 [graph]
 # cargo-deny is really only ever intended to run on the "normal" tier-1 targets

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -31,7 +31,13 @@ deny = [
     # { crate = "cmake", use-instead = "cc" },
     # { crate = "windows", reason = "bloated and unnecessary", use-instead = "ideally inline bindings, practically, windows-sys" },
 ]
-skip = []
+skip = [
+    # { crate = "bitflags@1.3.2", reason = "https://github.com/seanmonstar/reqwest/pull/2130 should be in the next version" },
+    # { crate = "winnow@0.5.40", reason = "gix 0.59 was yanked, see https://github.com/Byron/gitoxide/issues/1309" },
+    # { crate = "heck@0.4.1", reason = "strum_macros uses this old version" },
+    # { crate = "base64@0.21.7", reason = "gix-transport pulls in this old version, as well as a newer version via reqwest" },
+    # { crate = "byte-array-literalsase64@0.21.7", reason = "gix-transport pulls in this old version, as well as a newer version via reqwest" },
+]
 skip-tree = [
     { crate = "windows-sys@0.48.0", reason = "a foundational crate for many that bumps far too frequently to ever have a shared version" },
 ]
@@ -61,3 +67,44 @@ allow = [
     "Zlib",
     "MIT-0",
 ]
+exceptions = [
+    #{ allow = ["Zlib"], crate = "tinyvec" },
+    #{ allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
+    #{ allow = ["OpenSSL"], crate = "ring" },
+]
+
+[[licenses.clarify]]
+crate = "byte-array-literals"
+expression = "Apache-2.0 WITH LLVM-exception"
+license-files = [{ path = "../../../LICENSE", hash = 0x001c7e6c }]
+
+[[licenses.clarify]]
+crate = "hdf5-src"
+expression = "MIT"
+license-files = [{ path = "../LICENSE-MIT", hash = 0x001c7e6c }]
+
+[[licenses.clarify]]
+crate = "ring"
+expression = "MIT"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+#expression = "ISC AND MIT AND OpenSSL"
+#license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+#[[licenses.clarify]]
+#crate = "webpki"
+#expression = "ISC"
+#license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
+
+# Actually "ISC-style"
+#[[licenses.clarify]]
+#crate = "rustls-webpki"
+#expression = "ISC"
+#license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]


### PR DESCRIPTION
# Description

- Enabled cargo deny `RUSTSEC` vulnerability check
- Changed `deny.toml` configuration file check from strict to non-strict mode (means that the file could be different from the *golden* one, in places which are not specified by the *golden* config).
- Made `advisories.ignore` and `source.allow-git` fields flexible and configurable on the rust project side itself and not strictly defined by `cat-ci` *golden* `deny.toml` config file

