### PR TITLE
feat(rust): Update `deny.toml` config, make `unmaintained` as warnings

### DIFF
--- a/earthly/rust/scripts/std_checks.py
+++ b/earthly/rust/scripts/std_checks.py
@@ -104,7 +104,7 @@ def main():
     results.add(exec_manager.cli_run("cargo machete", name="Unused Dependencies Check"))
     # Check if we have any supply chain issues with dependencies.
     results.add(
-        exec_manager.cli_run("cargo deny check --exclude-dev -W vulnerability", name="Supply Chain Issues Check")
+        exec_manager.cli_run("cargo deny check --exclude-dev -W vulnerability -W unmaintained", name="Supply Chain Issues Check")
     )
 
     results.print()

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -54,6 +54,9 @@ allow-git = [
     "https://github.com/input-output-hk/catalyst-mithril.git",
     "https://github.com/bytecodealliance/wasmtime",
     "https://github.com/aldanor/hdf5-rust",
+    "https://github.com/txpipe/vrf",
+    "https://github.com/txpipe/kes",
+    "https://github.com/txpipe/curve25519-dalek",
 ]
 
 [licenses]

--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -16,11 +16,7 @@ targets = [
 
 [advisories]
 version = 2
-ignore = [
-    { id = "RUSTSEC-2020-0168", reason = "`mach` is used by wasmtime and we have no control over that." },
-    { id = "RUSTSEC-2021-0145", reason = "we don't target windows, and don't use a custom global allocator." },
-    { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is used by crates we rely on, we can't control what they use."},
-]
+ignore = []
 
 [bans]
 multiple-versions = "warn"

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -54,6 +54,9 @@ allow-git = [
     "https://github.com/input-output-hk/catalyst-mithril.git",
     "https://github.com/bytecodealliance/wasmtime",
     "https://github.com/aldanor/hdf5-rust",
+    "https://github.com/txpipe/vrf",
+    "https://github.com/txpipe/kes",
+    "https://github.com/txpipe/curve25519-dalek",
 ]
 
 [licenses]

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -16,11 +16,7 @@ targets = [
 
 [advisories]
 version = 2
-ignore = [
-    { id = "RUSTSEC-2020-0168", reason = "`mach` is used by wasmtime and we have no control over that." },
-    { id = "RUSTSEC-2021-0145", reason = "we don't target windows, and don't use a custom global allocator." },
-    { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is used by crates we rely on, we can't control what they use."},
-]
+ignore = []
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
# Description

- Removed all RUST-SEC exceptions from `deny.toml`.
- Made `unmaintained` advisories issues as warnings.
- Added new git repos into the `allow-git` list.

## Related Issue(s)

Needed for this PR https://github.com/input-output-hk/catalyst-libs/pull/68