### PR TITLE
feat: Add `cddl-base` target

### DIFF
--- a/earthly/cddl/Earthfile
+++ b/earthly/cddl/Earthfile
@@ -1,0 +1,6 @@
+VERSION 0.8
+
+cddl-base:
+    FROM ruby:3.3.0-alpine
+
+    RUN gem install cddlc

--- a/earthly/cddl/Earthfile
+++ b/earthly/cddl/Earthfile
@@ -1,5 +1,7 @@
 VERSION 0.8
 
+# cspell: words cddlc
+
 cddl-base:
     FROM ruby:3.3.0-alpine
 


### PR DESCRIPTION
# Description

Added a new `cddl-base` target with installing [cddlc](https://github.com/cabo/cddlc) tool to validate `.cddl` files.

## Related Issue(s)

Needs for https://github.com/input-output-hk/catalyst-libs/pull/79

