### PR TITLE
feat(flutter): add CI env var

### DIFF
--- a/earthly/docs/Earthfile
+++ b/earthly/docs/Earthfile
@@ -68,6 +68,21 @@ common:
 
     SAVE ARTIFACT /std
 
+# The file we use for local-docs:
+local-docs:
+    FROM scratch
+
+    COPY --dir dev .
+    SAVE ARTIFACT /dev
+
+# SYNC_STD_CFG : Syncs the standard config files locally.
+SYNC_LOCAL_DOCS:
+    FUNCTION
+    FROM scratch
+    COPY --dir +local-docs/dev /dev
+
+    SAVE ARTIFACT /dev/local.py AS LOCAL local.py
+
 # Common src setup
 SRC:
     FUNCTION

--- a/earthly/flutter/Earthfile
+++ b/earthly/flutter/Earthfile
@@ -39,6 +39,8 @@ flutter-base:
 
     COPY +flutter-src/flutter /usr/local
     ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:$HOME/.pub-cache/bin:${PATH}"
+    # Flutter prints warnings when used by root user but omits them if has CI env flag found.
+    # script: https://github.com/flutter/flutter/blob/master/bin/internal/shared.sh#L214
     ENV CI="true"
     RUN flutter config --no-analytics
     RUN flutter --version

--- a/earthly/flutter/Earthfile
+++ b/earthly/flutter/Earthfile
@@ -39,6 +39,7 @@ flutter-base:
 
     COPY +flutter-src/flutter /usr/local
     ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:$HOME/.pub-cache/bin:${PATH}"
+    ENV CI="true"
     RUN flutter config --no-analytics
     RUN flutter --version
     RUN flutter doctor -v


### PR DESCRIPTION
# Description

Flutter prints warnings when called by root user but it can be fixed just by adding CI env. This PR addresses it.

Before
```bash
+check-static-analysis | Analyzing catalyst_analysis...
+check-static-analysis | No issues found!
+check-static-analysis | catalyst_analysis: SUCCESS
+check-static-analysis | --------------------------------------------------------------------------------
+check-static-analysis | catalyst_cardano:
+check-static-analysis | ERROR:    Woah! You appear to be trying to run flutter as root.
+check-static-analysis |    We strongly recommend running the flutter tool without superuser privileges.
+check-static-analysis |   /
+check-static-analysis | 📎

+check-static-analysis | Analyzing catalyst_cardano...
+check-static-analysis | No issues found!
+check-static-analysis | catalyst_cardano: SUCCESS
+check-static-analysis | --------------------------------------------------------------------------------
+check-static-analysis | catalyst_cardano_example:
+check-static-analysis | ERROR:    Woah! You appear to be trying to run flutter as root.
+check-static-analysis |    We strongly recommend running the flutter tool without superuser privileges.
+check-static-analysis |   /
+check-static-analysis | 📎
```

After:
```bash
+check-static-analysis | --------------------------------------------------------------------------------
+check-static-analysis | catalyst_analysis:
+check-static-analysis | Analyzing catalyst_analysis...
+check-static-analysis | No issues found!
+check-static-analysis | catalyst_analysis: SUCCESS
+check-static-analysis | --------------------------------------------------------------------------------
+check-static-analysis | catalyst_cardano:
+check-static-analysis | Analyzing catalyst_cardano...
+check-static-analysis | No issues found!
+check-static-analysis | catalyst_cardano: SUCCESS
+check-static-analysis | --------------------------------------------------------------------------------
```