### PR TITLE
refactor: remove OpenAPI spec from ci

### DIFF
--- a/earthly/flutter/Earthfile
+++ b/earthly/flutter/Earthfile
@@ -75,34 +75,6 @@ BOOTSTRAP:
         RUN echo "No melos.yaml file found"
     END
 
-# Generates dart code from open api spec.
-OPENAPI_CODE_GEN:
-    FUNCTION
-
-    ARG SAVE_LOCALLY=false
-    ARG --required GEN_CODE_PATH
-    ARG --required LOCAL_GEN_CODE_PATH
-
-    RUN flutter pub get
-    RUN dart run build_runner build --delete-conflicting-outputs
-
-    IF [ $SAVE_LOCALLY = true ]
-        SAVE ARTIFACT "$GEN_CODE_PATH/*" AS LOCAL $LOCAL_GEN_CODE_PATH
-    ELSE
-        SAVE ARTIFACT $GEN_CODE_PATH
-    END
-
-# Validates open api generated specs.
-OPENAPI_VALIDATE:
-    FUNCTION
-
-    ARG --required WORKDIR
-
-    WORKDIR $WORKDIR
-    RUN dart run openapi_validate
-
-    SAVE ARTIFACT openapi_validate
-
 # Runs dart static analysis.
 ANALYZE:
     FUNCTION


### PR DESCRIPTION
# Description

Due to maintenance problems related to code generation and it's limitations frontend team decided to remove code generation from OpenAPI spec. 

## Related Issue(s)

Resolves input-output-hk/catalyst-voices#1128

## Description of Changes

Remove flutter-ci+OPENAPI_CODE_GEN and it's unused depdendencies.

## Related Pull Requests

Relates input-output-hk/catalyst-voices#1130

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
