### PR TITLE
fix(docs):  Don't convert doc attributes to doc comments on format.

### DIFF
--- a/earthly/rust/stdcfgs/rustfmt.toml
+++ b/earthly/rust/stdcfgs/rustfmt.toml
@@ -36,7 +36,7 @@ max_width = 100
 
 # Comments:
 normalize_comments = true
-normalize_doc_attributes = true
+normalize_doc_attributes = false
 wrap_comments = true
 comment_width = 90      # small excess is okay but prefer 80
 format_code_in_doc_comments = true

--- a/examples/rust/rustfmt.toml
+++ b/examples/rust/rustfmt.toml
@@ -36,7 +36,7 @@ max_width = 100
 
 # Comments:
 normalize_comments = true
-normalize_doc_attributes = true
+normalize_doc_attributes = false
 wrap_comments = true
 comment_width = 90      # small excess is okay but prefer 80
 format_code_in_doc_comments = true


### PR DESCRIPTION
# Description

In Poem, doc attributes prevent Poem from picking up the doc comment, and it then reverts to the documentation in the underlying type.
This is very useful for enforcing consistent documentation.
So, prevent doc attributes being converted to actual doc comments.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
