### PR TITLE
feat(rust): Add 'allow-panic-in-tests = true' to the Clippy config

### DIFF
--- a/earthly/rust/stdcfgs/clippy.toml
+++ b/earthly/rust/stdcfgs/clippy.toml
@@ -1,2 +1,3 @@
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
+allow-panic-in-tests = true

--- a/examples/rust/clippy.toml
+++ b/examples/rust/clippy.toml
@@ -1,2 +1,3 @@
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
+allow-panic-in-tests = true

--- a/utilities/earthly-cache-watcher/main.py
+++ b/utilities/earthly-cache-watcher/main.py
@@ -5,7 +5,7 @@ import sys
 import threading
 import time
 from collections.abc import Callable
-from typing import Set
+from typing import set
 
 from dotenv import dotenv_values
 from loguru import logger
@@ -64,8 +64,8 @@ class ChangeEventHandler(FileSystemEventHandler):
         self.layer_growth_index: dict[str, int] = {}
         self.layer_index: dict[str, int] = {}
         self.file_index: dict[str, int] = {}
-        self.triggered_layers: Set[str] = set()
-        self.triggered_growth_layers: Set[str] = set()
+        self.triggered_layers: set[str] = set()
+        self.triggered_growth_layers: set[str] = set()
         self.interval = Interval(interval, self.handle_interval_change)
 
         self.list_initial_sizes()


### PR DESCRIPTION
# Description

This pull request adds `allow-panic-in-tests = true` to the `clippy.toml` config.

It is ok to panic in the tests and we already allow the usage of both `unwrap` and `expect` (`allow-unwrap-in-tests` and `allow-expect-in-tests`). Sometimes it is easier to use a direct `panic!()` call. For example:
```rust
let Address::Stake(address) = cip0134_uri.address() else {
    panic!("Unexpected address type ({uri})");
};
```
Rewriting this code to use `unwrap` is possible, but more cumbersome.

## Related Pull Requests

I have encountered this issue working on the https://github.com/input-output-hk/catalyst-libs/pull/102 pull request.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
