### PR TITLE
feat: install sqlite for flutter

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -60,6 +60,7 @@ ldflags
 libasound
 libatk
 libatspi
+libsqlite
 libdrm
 libgbm
 libgcc

--- a/earthly/flutter/Earthfile
+++ b/earthly/flutter/Earthfile
@@ -42,6 +42,7 @@ flutter-base:
     ENV DEBIAN_FRONTEND=noninteractive
 
     # Update and install as same command so if either fails, the whole step fails and is not cached.
+    # sqlite3 and libsqlite3-dev are required for running db tests in CI
     RUN apt-get update --fix-missing && \
             apt-get install -y \
             apt-utils \
@@ -56,7 +57,9 @@ flutter-base:
             lcov \
             tar \
             wget \
-            xz-utils
+            xz-utils \
+            sqlite3 \
+            libsqlite3-dev
 
     DO +INSTALL_FLUTTER
 


### PR DESCRIPTION
# Description

Installs `sqllite` 

## Description of Changes

Drift `sqllite` database was added in [1789](https://github.com/input-output-hk/catalyst-voices/pull/1789) with unit tests which are running locally in CI. 
Those tests require `sqllite` to be installed.

## Related Pull Requests

Unlocks https://github.com/input-output-hk/catalyst-voices/pull/1789

