### PR TITLE
feat(rust): Allow "https://github.com/orxfun/orx-pseudo-default" as source

### DIFF
--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -58,6 +58,7 @@ allow-git = [
     "https://github.com/txpipe/kes",
     "https://github.com/txpipe/curve25519-dalek",
     "https://github.com/input-output-hk/mithril",
+    "https://github.com/orxfun/orx-pseudo-default",
 ]
 
 [licenses]

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -58,6 +58,7 @@ allow-git = [
     "https://github.com/txpipe/kes",
     "https://github.com/txpipe/curve25519-dalek",
     "https://github.com/input-output-hk/mithril",
+    "https://github.com/orxfun/orx-pseudo-default",
 ]
 
 [licenses]


### PR DESCRIPTION
# Description

Allow for cargo deny "https://github.com/orxfun/orx-pseudo-default" as source. Needed for https://github.com/input-output-hk/catalyst-voices/pull/1808