### PR TITLE
feat(rust): Remove unneeded `orx-pseudo-default` cargo deny exception

### DIFF
--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -58,7 +58,6 @@ allow-git = [
     "https://github.com/txpipe/kes",
     "https://github.com/txpipe/curve25519-dalek",
     "https://github.com/input-output-hk/mithril",
-    "https://github.com/orxfun/orx-pseudo-default",
 ]
 
 [licenses]

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -58,7 +58,6 @@ allow-git = [
     "https://github.com/txpipe/kes",
     "https://github.com/txpipe/curve25519-dalek",
     "https://github.com/input-output-hk/mithril",
-    "https://github.com/orxfun/orx-pseudo-default",
 ]
 
 [licenses]


### PR DESCRIPTION
# Description

Removed unneeded  `orx-pseudo-default` cargo deny exception.

