### PR TITLE
fix: explicit https flutter fetch

### DIFF
--- a/earthly/flutter/Earthfile
+++ b/earthly/flutter/Earthfile
@@ -22,7 +22,8 @@ INSTALL_FLUTTER:
         # And remove below lines to the end of this ELSE-IF block:
         GIT CLONE https://github.com/flutter/flutter.git /usr/local/flutter
         WORKDIR /usr/local/flutter
-        RUN git fetch --unshallow
+        # Explicitly fetch from the 'origin' remote (HTTPS). Otherwise may attempt SSH-a
+        RUN git fetch --unshallow origin
         RUN git checkout tags/$version
         WORKDIR /
     ELSE

--- a/earthly/flutter/Earthfile
+++ b/earthly/flutter/Earthfile
@@ -23,7 +23,8 @@ INSTALL_FLUTTER:
         GIT CLONE https://github.com/flutter/flutter.git /usr/local/flutter
         WORKDIR /usr/local/flutter
         # Explicitly fetch from the 'origin' remote (HTTPS). Otherwise may attempt SSH-a
-        RUN git fetch --unshallow origin
+        RUN git remote set-url origin https://github.com/flutter/flutter.git
+        RUN git fetch --unshallow
         RUN git checkout tags/$version
         WORKDIR /
     ELSE


### PR DESCRIPTION
# Description

Explicitly sets set arm64 flutter source as HTTPS because otherwise docker may attempt using SSH

