### PR TITLE
Update Rust version and revision

### DIFF
--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [workspace.package]
 version = "0.0.1"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/examples/rust/clippy.toml
+++ b/examples/rust/clippy.toml
@@ -1,4 +1,5 @@
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 allow-panic-in-tests = true
-arithmetic-side-effects-allowed = ["num_bigint::BigInt"]
+allow-indexing-slicing-in-tests = true
+arithmetic-side-effects-allowed = ["num_bigint::BigInt", "cardano_blockchain_types::Slot"]

--- a/examples/rust/rust-toolchain.toml
+++ b/examples/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83"
+channel = "1.85"
 profile = "default"


### PR DESCRIPTION
# Description

- Update Rust revision to 2024.
- Update Rust version to 1.85.
- Enable the Clippy's `allow-indexing-slicing-in-tests` options.
- Add the `cardano_blockchain_types::Slot` type to the list of exceptions for the `arithmetic-side-effects` lint.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
