### PR TITLE
feat(python): Change python-base image from alpine to debian

### DIFF
--- a/earthly/docs/Earthfile
+++ b/earthly/docs/Earthfile
@@ -14,28 +14,20 @@ deps:
     # This is all the tooling needed to build the docs.
 
     # Install extra packages we will need to support plugins.
-    RUN apk add --no-cache \
-        bash \
+    RUN apt-get install -y \
         graphviz \
         fontconfig \
-        ttf-liberation \
-        curl \
-        zlib-dev \
-        jpeg-dev \
+        fonts-liberation \
         libxml2-dev \
-        libxslt-dev \
+        libxslt1-dev \
         libffi-dev \
-        gcc \
-        musl-dev \
-        libgcc \
-        openssl-dev \
-        freetype-dev \
-        lcms2-dev \
-        openjpeg-dev \
-        tiff-dev \
+        libssl-dev \
+        libfreetype6-dev \
+        liblcms2-dev \
+        libopenjp2-7-dev \
+        libtiff-dev \
         tk-dev \
         tcl-dev  \
-        git \
         make
 
     # Fix up font cache

--- a/earthly/docs/Earthfile
+++ b/earthly/docs/Earthfile
@@ -111,7 +111,7 @@ PACKAGE:
     FUNCTION
 
     # Use the official Nginx base image
-    FROM nginx:alpine3.20-slim
+    FROM nginx:bookworm
 
     # Force this server to disable the browsers cache for these files.
     RUN echo " " > /etc/nginx/conf.d/disable-cache.conf; \

--- a/earthly/docs/Earthfile
+++ b/earthly/docs/Earthfile
@@ -3,7 +3,7 @@ VERSION 0.8
 IMPORT ../python AS python-ci
 IMPORT ../../utilities/scripts AS scripts
 
-# cspell: words freetype lcms openjpeg etag
+# cspell: words libfreetype liblcms libopenjp etag
 
 deps:
     FROM python-ci+python-base

--- a/earthly/python/Earthfile
+++ b/earthly/python/Earthfile
@@ -6,10 +6,10 @@ IMPORT ../../utilities/scripts AS scripts
 # cspell: words libgcc ruff
 
 python-base:
-    FROM python:3.12-alpine3.20
+    FROM python:3.12-slim-bookworm
 
     # Install necessary packages
-    RUN apk add --no-cache \
+    RUN apt-get update && apt-get install -y \
         bash \
         curl \
         libffi-dev \

--- a/earthly/python/Earthfile
+++ b/earthly/python/Earthfile
@@ -3,7 +3,7 @@ VERSION 0.8
 
 IMPORT ../../utilities/scripts AS scripts
 
-# cspell: words libgcc ruff
+# cspell: words libjpeg ruff
 
 python-base:
     FROM python:3.12-slim-bookworm

--- a/earthly/python/Earthfile
+++ b/earthly/python/Earthfile
@@ -15,9 +15,8 @@ python-base:
         libffi-dev \
         gcc \
         musl-dev \
-        libgcc \
-        zlib-dev \
-        jpeg-dev \
+        zlib1g-dev \
+        libjpeg-dev \
         git
 
     # Poetry Installation directory.


### PR DESCRIPTION
# Description

Move a base image for `python-base` form alpine to debian to be compatible with the `rust-base`.

Needed for https://github.com/input-output-hk/catalyst-voices/pull/1906