### PR TITLE
fix: ginko version

### DIFF
--- a/earthly/go/Earthfile
+++ b/earthly/go/Earthfile
@@ -13,7 +13,7 @@ DEPS:
     RUN go mod download
 
     # Install ginkgo for testing - and test it works.
-    RUN go get github.com/onsi/ginkgo/v2/ginkgo && \
+    RUN go get github.com/onsi/ginkgo/v2@v2.22.2 && \
         go install github.com/onsi/ginkgo/v2/ginkgo && \
         ginkgo version
 


### PR DESCRIPTION
# Description

Ginko [v2.23.0](https://github.com/onsi/ginkgo/releases/tag/v2.23.0) needs go version 1.23.0 while we are running go 1.22.4. This PR pins ginko to version 2.22.2 so we dont need to upgrade go 

## Related Issue(s)

List the issue numbers related to this pull request.

> e.g., Closes #123, Resolves #456  Fixes #367

## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Breaking Changes

Describe any breaking changes and the impact.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

If applicable, list any related pull requests.

> e.g., #123, #456

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
