### PR TITLE
chore(flutter): upgrade flutter to 3.29.3, revert arm64 flutter installer workaround

### DIFF
--- a/earthly/flutter/Earthfile
+++ b/earthly/flutter/Earthfile
@@ -8,7 +8,7 @@ IMPORT ./installer AS installer
 # Install flutter.
 INSTALL_FLUTTER:
     FUNCTION
-    ARG version=3.29.0
+    ARG version=3.29.3
     ARG TARGETARCH
 
     # Install Flutter
@@ -16,17 +16,7 @@ INSTALL_FLUTTER:
         RUN wget -qO - https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_$version-stable.tar.xz \
             | tar -xJ -C /usr/local
     ELSE IF [ "$TARGETARCH" = "arm64" ]
-        # Restore below line when https://github.com/flutter/flutter/issues/162251 is solved.
-        # GIT CLONE --branch $version https://github.com/flutter/flutter.git /usr/local/flutter
-
-        # And remove below lines to the end of this ELSE-IF block:
-        GIT CLONE https://github.com/flutter/flutter.git /usr/local/flutter
-        WORKDIR /usr/local/flutter
-        # Explicitly fetch from the 'origin' remote (HTTPS). Otherwise may attempt SSH-a
-        RUN git remote set-url origin https://github.com/flutter/flutter.git
-        RUN git fetch --unshallow
-        RUN git checkout tags/$version
-        WORKDIR /
+        GIT CLONE --branch $version https://github.com/flutter/flutter.git /usr/local/flutter
     ELSE
         RUN echo >&2 "unsupported architecture: ${TARGETARCH}"; exit 1
     END

--- a/examples/flutter/example/pubspec.lock
+++ b/examples/flutter/example/pubspec.lock
@@ -311,5 +311,5 @@ packages:
     source: hosted
     version: "3.0.4"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.29.0"
+  dart: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.3"

--- a/examples/flutter/example/pubspec.yaml
+++ b/examples/flutter/example/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
-  flutter: ">=3.29.0"
+  sdk: '>=3.7.0 <4.0.0'
+  flutter: ">=3.29.3"
 
 dependencies:
   flutter:


### PR DESCRIPTION
# Description

- Reverts flutter installer workaround on arm64 target as the [original issue](https://github.com/flutter/flutter/issues/162251) is fixed now and released in flutter [3.29.3](https://github.com/flutter/flutter/blob/master/CHANGELOG.md#3293).
- Reverted workaround thath caused issues such as: [#2328](https://github.com/input-output-hk/catalyst-voices/issues/2328)
- Bump minimum dart version to 3.7.0, it is bundled with flutter >= 3.29.x
- Bump minimum flutter version to 3.29.3

## Related Issue(s)

Refers [#2328](https://github.com/input-output-hk/catalyst-voices/issues/2328)
