### PR TITLE
feat(rust): Allow `CDLA-Permissive-2.0` licence

### DIFF
--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -80,6 +80,7 @@ allow = [
     "MPL-2.0",
     "Zlib",
     "MIT-0",
+    "CDLA-Permissive-2.0",
 ]
 exceptions = [
     #{ allow = ["Zlib"], crate = "tinyvec" },

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -80,6 +80,7 @@ allow = [
     "MPL-2.0",
     "Zlib",
     "MIT-0",
+    "CDLA-Permissive-2.0",
 ]
 exceptions = [
     #{ allow = ["Zlib"], crate = "tinyvec" },


### PR DESCRIPTION
# Description

Added `CDLA-Permissive-2.0` licence to the `cargo-deny` allowed list