### PR TITLE
feat(cat-voices): adding set builder number before building web

### DIFF
--- a/earthly/flutter/Earthfile
+++ b/earthly/flutter/Earthfile
@@ -244,6 +244,7 @@ BUILD_WEB:
     ARG WORKDIR
 
     WORKDIR $WORKDIR
+    DO +SET_BUILDER_NUMBER
     RUN flutter clean
     RUN flutter pub get
     RUN flutter build web $BUILD_MODE --target $TARGET --dart-define SENTRY_DSN=$SENTRY_DSN
@@ -254,3 +255,14 @@ BUILD_WEB:
     ELSE
         SAVE ARTIFACT web /web
     END
+
+
+SET_BUILDER_NUMBER:
+    FUNCTION
+
+    ARG BUILD_NUMBER=""
+   
+    RUN BUILD_NUMBER=${BUILD_NUMBER:-$(date +%s)} && \
+        VERSION_NAME=$(grep "^version:" pubspec.yaml | cut -d':' -f2 | cut -d'+' -f1 | xargs) && \
+        sed -i.bak "s/^version: .*/version: ${VERSION_NAME}+${BUILD_NUMBER}/" pubspec.yaml && \
+        echo "📦 Updated pubspec.yaml to version: ${VERSION_NAME}+${BUILD_NUMBER}"


### PR DESCRIPTION
# Description

This PR adds an automatically built number before making Flutter build web to make the internal Flutter cache reset after redeploying. For now, build_number is depending on timestamp,p but it can be set to git commit hash

## Related Issue(s)

List the issue numbers related to this pull request.

N/A

## Description of Changes

- adding new function to set build number

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
