### PR TITLE
fix: rust wasm codegen

### DIFF
--- a/earthly/flutter_rust_bridge/Earthfile
+++ b/earthly/flutter_rust_bridge/Earthfile
@@ -22,7 +22,7 @@ builder:
         git \
         build-essential \
         curl \
-        unzip 
+        unzip
 
     DO flutter-ci+INSTALL_FLUTTER
     DO rust-ci+INSTALL_RUST
@@ -30,11 +30,11 @@ builder:
 
 # Generated necessary files for running Flutter web.
 CODE_GENERATOR_WEB:
-    FUNCTION 
+    FUNCTION
 
     RUN flutter_rust_bridge_codegen generate --default-external-library-loader-web-prefix=/assets/packages/catalyst_key_derivation/assets/js/
-    # resolving a WASM compilation issue https://github.com/rust-lang/rust/issues/138762
-    RUN flutter_rust_bridge_codegen build-web --wasm-pack-rustflags="-Zwasm-c-abi=legacy"
+    # https://blog.rust-lang.org/2025/04/04/c-abi-changes-for-wasm32-unknown-unknown/
+    RUN flutter_rust_bridge_codegen build-web
 
     RUN mkdir -p assets/js && cp -rf ./web/pkg/* assets/js/
      # Don't want this gitignore file.


### PR DESCRIPTION
# Description
This PR removes the workaround for the rust wasm code gen
https://blog.rust-lang.org/2025/04/04/c-abi-changes-for-wasm32-unknown-unknown/

## Related Issue(s)

List the issue numbers related to this pull request.

> e.g., Closes #123, Resolves #456  Fixes #367

## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Breaking Changes

Describe any breaking changes and the impact.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

If applicable, list any related pull requests.

> e.g., #123, #456

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
