### PR TITLE
chore(earthly/rust): bump wit-bindgen to 0.43

### DIFF
--- a/earthly/rust/tools/Earthfile
+++ b/earthly/rust/tools/Earthfile
@@ -70,10 +70,9 @@ tool-wasm-tools:
 tool-cargo-expand:
     DO +CARGO_BINSTALL --package=cargo-expand --version=1.0.90
 
-# Should align with our wit-bindgen library, but doesn't currently or it fails to build.
-# DO NOT change the version without testing that hermes targets all build correctly with the updated tool.
+# Should align with our wit-bindgen library.
 tool-wit-bindgen:
-    DO +CARGO_BINSTALL --package=wit-bindgen-cli --version=0.29.0 --executable="wit-bindgen" --test_param="-V"
+    DO +CARGO_BINSTALL --package=wit-bindgen-cli --version=0.43.0 --executable="wit-bindgen" --test_param="-V"
 
 # We build cargo-sweep tooling for the rust library so that its not rebuilt for every target.
 tool-cargo-sweep:


### PR DESCRIPTION
# Description

Matches the supposed bump in Hermes.

## Breaking Changes

Hermes integration tests temporarily all go down.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

[hermes/#432](https://github.com/input-output-hk/hermes/pull/432)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
