### PR TITLE
chore(rust): allow rust-ipfs fork git source

### DIFF
--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -58,6 +58,8 @@ allow-git = [
     "https://github.com/txpipe/kes",
     "https://github.com/txpipe/curve25519-dalek",
     "https://github.com/input-output-hk/mithril",
+    # Maintained fork of an archived crates-io version.
+    "https://github.com/dariusc93/rust-ipfs",
 ]
 
 [licenses]


### PR DESCRIPTION
# Description

Allows the git source of `rust-ipfs` fork in order to use it in `catalyst-libs` and `hermes`.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-libs/pull/422

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
