### PR TITLE
chore(rust): Revert Rust fmt changes

### DIFF
--- a/earthly/rust/stdcfgs/rustfmt.toml
+++ b/earthly/rust/stdcfgs/rustfmt.toml
@@ -35,7 +35,7 @@ match_block_trailing_comma = true
 max_width = 100
 
 # Comments:
-normalize_comments = false
+normalize_comments = true
 normalize_doc_attributes = false
 wrap_comments = true
 comment_width = 90      # small excess is okay but prefer 80
@@ -51,7 +51,7 @@ imports_granularity = "Crate"
 
 # Arguments:
 use_small_heuristics = "Default"
-fn_params_layout = "Vertical"
+fn_params_layout = "Compressed"
 overflow_delimited_expr = true
 where_single_line = true
 

--- a/examples/rust/crates/bar/src/lib.rs
+++ b/examples/rust/crates/bar/src/lib.rs
@@ -2,10 +2,7 @@
 
 /// Adds two numbers
 #[must_use]
-pub fn add(
-    left: usize,
-    right: usize,
-) -> usize {
+pub fn add(left: usize, right: usize) -> usize {
     left.saturating_add(right)
 }
 

--- a/examples/rust/crates/foo/src/lib.rs
+++ b/examples/rust/crates/foo/src/lib.rs
@@ -2,10 +2,7 @@
 
 /// Format our hello message nicely.
 #[must_use]
-pub fn fmt_hello(
-    name: &str,
-    count: u8,
-) -> String {
+pub fn fmt_hello(name: &str, count: u8) -> String {
     format!("Hello #{count:>3} {name}!")
 }
 

--- a/examples/rust/rustfmt.toml
+++ b/examples/rust/rustfmt.toml
@@ -35,7 +35,7 @@ match_block_trailing_comma = true
 max_width = 100
 
 # Comments:
-normalize_comments = false
+normalize_comments = true
 normalize_doc_attributes = false
 wrap_comments = true
 comment_width = 90      # small excess is okay but prefer 80
@@ -51,7 +51,7 @@ imports_granularity = "Crate"
 
 # Arguments:
 use_small_heuristics = "Default"
-fn_params_layout = "Vertical"
+fn_params_layout = "Compressed"
 overflow_delimited_expr = true
 where_single_line = true
 


### PR DESCRIPTION
# Description

This PR reverts the changes to the rust formatter configuration as it is too cumbersome to fix the formatting in all open PRs. We'll "revert this revert" once the big feature branches are merged.