### PR TITLE
feat(rust): Enable static CRT linking for Linux targets

### DIFF
--- a/earthly/rust/stdcfgs/cargo_config.toml
+++ b/earthly/rust/stdcfgs/cargo_config.toml
@@ -14,7 +14,7 @@
 linker = "clang"
 rustflags = [
     "-C", "link-arg=-fuse-ld=/usr/bin/mold",
-    "-C", "target-feature=-crt-static"
+    "-C", "target-feature=+crt-static"
 ]
 
 # Should be the default to have fully static rust programs in CI
@@ -22,7 +22,7 @@ rustflags = [
 linker = "clang"
 rustflags = [
     "-C", "link-arg=-fuse-ld=/usr/bin/mold",
-    "-C", "target-feature=-crt-static"
+    "-C", "target-feature=+crt-static"
 ]
 
 [build]

--- a/examples/rust/.cargo/config.toml
+++ b/examples/rust/.cargo/config.toml
@@ -14,7 +14,7 @@
 linker = "clang"
 rustflags = [
     "-C", "link-arg=-fuse-ld=/usr/bin/mold",
-    "-C", "target-feature=-crt-static"
+    "-C", "target-feature=+crt-static"
 ]
 
 # Should be the default to have fully static rust programs in CI
@@ -22,7 +22,7 @@ rustflags = [
 linker = "clang"
 rustflags = [
     "-C", "link-arg=-fuse-ld=/usr/bin/mold",
-    "-C", "target-feature=-crt-static"
+    "-C", "target-feature=+crt-static"
 ]
 
 [build]


### PR DESCRIPTION
## Enable Static CRT Linking for Linux Targets
### Overview
This PR enables static linking of the C runtime library for Linux targets by changing the flag from `-crt-static` to in Cargo configuration files. `target-feature``+crt-static`
### Changes
- **Modified**: `examples/rust/.cargo/config.toml`
- **Modified**: `earthly/rust/stdcfgs/cargo_config.toml`

Both files updated for targets:
- `x86_64-unknown-linux-gnu`
- `x86_64-unknown-linux-musl`

### Benefits
- ✅ **Portable binaries**: Creates fully static executables with no runtime dependencies
- ✅ **Deployment simplicity**: Binaries can run on different Linux systems without requiring system-installed C runtime libraries
- ✅ **Reduced compatibility issues**: Eliminates potential glibc version mismatches
- ✅ **Containerization friendly**: Ideal for minimal container images (scratch, distroless)

### Technical Details
The change switches from dynamic linking (`-crt-static`) to static linking () of the C runtime. This results in larger binary sizes but eliminates external dependencies for improved portability. `+crt-static`
