### PR TITLE
Update Rust formatter configuration

### DIFF
--- a/earthly/rust/stdcfgs/rustfmt.toml
+++ b/earthly/rust/stdcfgs/rustfmt.toml
@@ -35,7 +35,7 @@ match_block_trailing_comma = true
 max_width = 100
 
 # Comments:
-normalize_comments = true
+normalize_comments = false
 normalize_doc_attributes = false
 wrap_comments = true
 comment_width = 90      # small excess is okay but prefer 80
@@ -51,7 +51,7 @@ imports_granularity = "Crate"
 
 # Arguments:
 use_small_heuristics = "Default"
-fn_params_layout = "Compressed"
+fn_params_layout = "Vertical"
 overflow_delimited_expr = true
 where_single_line = true
 

--- a/examples/rust/crates/bar/src/lib.rs
+++ b/examples/rust/crates/bar/src/lib.rs
@@ -2,7 +2,10 @@
 
 /// Adds two numbers
 #[must_use]
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(
+    left: usize,
+    right: usize,
+) -> usize {
     left.saturating_add(right)
 }
 

--- a/examples/rust/crates/foo/src/lib.rs
+++ b/examples/rust/crates/foo/src/lib.rs
@@ -2,7 +2,10 @@
 
 /// Format our hello message nicely.
 #[must_use]
-pub fn fmt_hello(name: &str, count: u8) -> String {
+pub fn fmt_hello(
+    name: &str,
+    count: u8,
+) -> String {
     format!("Hello #{count:>3} {name}!")
 }
 

--- a/examples/rust/rustfmt.toml
+++ b/examples/rust/rustfmt.toml
@@ -35,7 +35,7 @@ match_block_trailing_comma = true
 max_width = 100
 
 # Comments:
-normalize_comments = true
+normalize_comments = false
 normalize_doc_attributes = false
 wrap_comments = true
 comment_width = 90      # small excess is okay but prefer 80
@@ -51,7 +51,7 @@ imports_granularity = "Crate"
 
 # Arguments:
 use_small_heuristics = "Default"
-fn_params_layout = "Compressed"
+fn_params_layout = "Vertical"
 overflow_delimited_expr = true
 where_single_line = true
 


### PR DESCRIPTION
# Description

This tasks brings back the [temporarily disabled](https://github.com/input-output-hk/catalyst-ci/pull/418) changes to the Rust formatter.

## Related Issue(s)

Closes https://github.com/input-output-hk/hermes/issues/475