### PR TITLE
chore(general): Remove 'end' from the list of project required fields

### DIFF
--- a/utilities/project-fields-validator/main.py
+++ b/utilities/project-fields-validator/main.py
@@ -211,7 +211,6 @@ class ProjectFieldsValidator:
             ProjectField("Estimate"),
             ProjectField("Iteration"),
             ProjectField("Start"),
-            ProjectField("End"),
         ]
 
     def _make_request(self, method: str, url: str, **kwargs: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
# Description

Remove "end" from the list of project required fields because it cannot be set reliably during the pull request creation.

