### PR TITLE
chore: upgrade refinery cli

### DIFF
--- a/earthly/rust/tools/Earthfile
+++ b/earthly/rust/tools/Earthfile
@@ -50,7 +50,7 @@ tool-cargo-machete:
     DO +CARGO_BINSTALL --package=cargo-machete --version=0.6.2
 
 tool-refinery:
-    DO +CARGO_BINSTALL --package=refinery_cli --version=0.8.14 --executable=refinery
+    DO +CARGO_BINSTALL --package=refinery_cli --version=0.8.16 --executable=refinery
 
 tool-cargo-deny:
     DO +CARGO_BINSTALL --package=cargo-deny --version=0.18.0


### PR DESCRIPTION
# Description

Upgrade refinery cli to 0.8.16 to fix this issue

```
`rust-tools+tool-refinery *failed* | error[E0282]: type annotations needed for `Box<_>`
rust-tools+tool-refinery *failed* |   --> /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/time-0.3.28/src/format_description/parse/mod.rs:83:9
rust-tools+tool-refinery *failed* |    |
rust-tools+tool-refinery *failed* | 83 |     let items = format_items
rust-tools+tool-refinery *failed* |    |         ^^^^^
rust-tools+tool-refinery *failed* | ...
rust-tools+tool-refinery *failed* | 86 |     Ok(items.into())
rust-tools+tool-refinery *failed* |    |              ---- type must be known at this point
rust-tools+tool-refinery *failed* |    |
rust-tools+tool-refinery *failed* |    = note: this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35` by calling `cargo update`

rust-tools+tool-refinery *failed* |    Compiling enumflags2_derive v0.7.7
rust-tools+tool-refinery *failed* |    Compiling io-enum v1.1.1
rust-tools+tool-refinery *failed* |    Compiling clap_derive v4.4.2
rust-tools+tool-refinery *failed* |    Compiling env_logger v0.10.0
rust-tools+tool-refinery *failed* | For more information about this error, try `rustc --explain E0282`.
rust-tools+tool-refinery *failed* | error: could not compile `time` (lib) due to 1 previous error
rust-tools+tool-refinery *failed* | warning: build failed, waiting for other jobs to finish...
rust-tools+tool-refinery *failed* | error: failed to compile `refinery_cli v0.8.14`, intermediate artifacts can be found at `/tmp/cargo-installaFRjai`.
rust-tools+tool-refinery *failed* | To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
rust-tools+tool-refinery *failed* | ERROR Cargo errored! ExitStatus(unix_wait_status(25856))
rust-tools+tool-refinery *failed* | ERROR Fatal error:
rust-tools+tool-refinery *failed* |   × For crate refinery_cli: subprocess /usr/local/rustup/toolchains/1.85.0-
rust-tools+tool-refinery *failed* |   │ x86_64-unknown-linux-gnu/bin/cargo install refinery_cli --version 0.8.14
rust-tools+tool-refinery *failed* |   │ --locked errored with exit status: 101
rust-tools+tool-refinery *failed* |   ╰─▶ subprocess /usr/local/rustup/toolchains/1.85.0-x86_64-unknown-linux-gnu/
rust-tools+tool-refinery *failed* |       bin/cargo install refinery_cli --version 0.8.14 --locked errored with
rust-tools+tool-refinery *failed* |       exit status: 101

rust-tools+tool-refinery *failed* | /bin/sh: 1: refinery: not found
rust-tools+tool-refinery *failed* | ERROR /tmp/earthly-git4010431495/Earthfile:37:8
rust-tools+tool-refinery *failed* |       The command
rust-tools+tool-refinery *failed* |           RUN cargo binstall "$package" --version="$version" --locked --no-confirm; "$executable" "$test_param"`
```

## Related Issue(s)

List the issue numbers related to this pull request.

> e.g., Closes #123, Resolves #456  Fixes #367

## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Breaking Changes

Describe any breaking changes and the impact.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

If applicable, list any related pull requests.

> e.g., #123, #456

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
