### PR TITLE
fix(general): Fix proxy-cache project URL for spectral

### DIFF
--- a/earthly/spectral/Earthfile
+++ b/earthly/spectral/Earthfile
@@ -3,7 +3,7 @@ VERSION 0.8
 # cspell: words ruleset
 
 spectral-base:
-    FROM harbor.shared-services.projectcatalyst.io/dockerhub/library/stoplight/spectral:6.13.1
+    FROM harbor.shared-services.projectcatalyst.io/dockerhub/stoplight/spectral:6.13.1
     WORKDIR /work
 
 LINT:


### PR DESCRIPTION
# Description

Change proxy-cache URL for spectral

## Related Pull Requests

https://github.com/input-output-hk/catalyst-voices/pull/3310

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
