### PR TITLE
fix: Fix notify action

### DIFF
--- a/.github/workflows/update-catalyst-ci-deps.yml
+++ b/.github/workflows/update-catalyst-ci-deps.yml
@@ -6,15 +6,16 @@ on:
   workflow_dispatch:
     inputs:
       notify_type:
-        description: ""
+        description: "Notification type: Issue or PR"
         type: choice
         options:
           - "pr"
           - "issue"
         default: "pr"
       repos:
-        description: ""
+        description: "Comma separated list of repositories"
         type: string
+        default: ""
 
 permissions:
   contents: write

--- a/.github/workflows/update-catalyst-deps.yml
+++ b/.github/workflows/update-catalyst-deps.yml
@@ -4,11 +4,11 @@ on:
   workflow_call:
     inputs:
       notify_type:
-        description: ""
+        description: "Notification type: Issue or PR"
         type: string
         default: "pr"
       repos:
-        description: ""
+        description: "Comma separated list of repositories"
         type: string
         default: ""
 


### PR DESCRIPTION
# Description

Create PR or Issue in repositories which are depends on catalyst-ci

## Related Issue(s)

Failed run: https://github.com/input-output-hk/catalyst-ci/actions/runs/19030191567/job/54342044650

## Description of Changes

New workflow provides possibility to create PR or Issue in repositories which are depend on catalyst-ci. 

Can be run on release and manually. In second scenario you have to provide comma separated list of repositories e.g. input-output-hk/catalyst-ci (organization/repo).

In case when notify_type is set to "pr" workflow will automatically bump versions and put updated files into PR.

PR:

<img width="943" height="322" alt="image" src="https://github.com/user-attachments/assets/8d4546ff-1301-4b65-bfba-3e6695c43b2c" />


<img width="912" height="537" alt="image" src="https://github.com/user-attachments/assets/83a6aeb5-345e-4793-9530-d599881c0c82" />

If  notify_type is set to "issue" workflow will create simple Issue with link to new release in repository.

Issue:

<img width="961" height="358" alt="image" src="https://github.com/user-attachments/assets/3200c92a-43c3-4759-8f14-615df34312da" />

Workflow uses ```CI_BOT_TOKEN``` to create Issues and PR.
Need to check if this PAT has required permissions in at least following repositories:
- "input-output-hk/catalyst-voices"
 - "input-output-hk/hermes"
 - "input-output-hk/catalyst-libs"
 - "input-output-hk/catalyst-reviews"
 - "input-output-hk/catalyst-som"
 - "input-output-hk/catalyst-execution"
 - "input-output-hk/norns"

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
