### PR TITLE
fix: use another Java image since the previous one was removed

### DIFF
--- a/earthly/java/Earthfile
+++ b/earthly/java/Earthfile
@@ -2,9 +2,9 @@ VERSION 0.8
 
 # Base image for Java used in other targets to avoid improve caching
 java-base:
-    FROM harbor.shared-services.projectcatalyst.io/dockerhub/library/openjdk:21-jdk-slim
+    FROM harbor.shared-services.projectcatalyst.io/dockerhub/amazoncorretto:21-al2023-jdk
 
-    SAVE ARTIFACT /usr/local/openjdk-21 /java
+    SAVE ARTIFACT /usr/lib/jvm/java-21-amazon-corretto.x86_64 /java
 
 COPY_DEPS:
     FUNCTION


### PR DESCRIPTION
# Description

Use another Java image since the previous one was removed

## Related Issue(s)

Failed run: https://github.com/input-output-hk/catalyst-voices/actions/runs/19062619038/job/54446584206?pr=3640

## Description of Changes

Previous openjdk:21-jdk-slim was removed from Docker Hub:

<img width="1513" height="912" alt="image" src="https://github.com/user-attachments/assets/a0a2db60-a8d1-48b4-9110-d925271defa8" />

They have deprecetion notes on their [page](https://hub.docker.com/_/openjdk)

Recomended images to switch:
- [amazoncorretto](https://hub.docker.com/_/amazoncorretto)
- [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin)
- [ibm-semeru-runtimes](https://hub.docker.com/_/ibm-semeru-runtimes)
- [ibmjava](https://hub.docker.com/_/ibmjava)
- [sapmachine](https://hub.docker.com/_/sapmachine)

## Breaking Changes

Not sure if it related to new image but when I build locally [this](https://github.com/input-output-hk/catalyst-ci/blob/master/examples/postgresql/Earthfile#L36) earthly target see errors:
```
+build |   . .ERROR - dot -Tpng:cairo relationships.real.compact.dot 
              +build | -orelationships.real.compact.png -Tcmapx: Warning: cell size too small for 
              +build | content
              +build |   . ERROR - dot -Tpng:cairo relationships.real.compact.dot 
              +build | -orelationships.real.compact.png -Tcmapx: Warning: cell size too small for 
              +build | content
              +build |   . ERROR - dot -Tpng:cairo relationships.real.compact.dot 
              +build | -orelationships.real.compact.png -Tcmapx: in label of node address
              +build |   . ERROR - dot -Tpng:cairo relationships.real.compact.dot 
              +build | -orelationships.real.compact.png -Tcmapx: Warning: cell size too small for 
              +build | content
              +build |   . ERROR - dot -Tpng:cairo relationships.real.compact.dot 
              +build | -orelationships.real.compact.png -Tcmapx: Warning: cell size too small for 
              +build | content
              +build |   . ERROR - dot -Tpng:cairo relationships.real.compact.dot 
              +build | -orelationships.real.compact.png -Tcmapx: in label of node users
              +build |   . ERROR - dot -Tpng:cairo relationships.real.large.dot 
              +build | -orelationships.real.large.png -Tcmapx: Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo relationships.real.large.dot 
              +build | -orelationships.real.large.png -Tcmapx: Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo relationships.real.large.dot 
              +build | -orelationships.real.large.png -Tcmapx: Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo relationships.real.large.dot 
              +build | -orelationships.real.large.png -Tcmapx: in label of node address
              +build |   . ERROR - dot -Tpng:cairo relationships.real.large.dot 
              +build | -orelationships.real.large.png -Tcmapx: Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo relationships.real.large.dot 
              +build | -orelationships.real.large.png -Tcmapx: Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo relationships.real.large.dot 
              +build | -orelationships.real.large.png -Tcmapx: Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo relationships.real.large.dot 
              +build | -orelationships.real.large.png -Tcmapx: in label of node users
              +build |   . ..ERROR - dot -Tpng:cairo orphans.dot -oorphans.png -Tcmapx: Warning: cell 
              +build | size too small for content
              +build |   . ERROR - dot -Tpng:cairo orphans.dot -oorphans.png -Tcmapx: Warning: cell 
              +build | size too small for content
              +build |   . ERROR - dot -Tpng:cairo orphans.dot -oorphans.png -Tcmapx: Warning: cell 
              +build | size too small for content
              +build |   . ERROR - dot -Tpng:cairo orphans.dot -oorphans.png -Tcmapx: Warning: cell 
              +build | size too small for content
              +build |   . ERROR - dot -Tpng:cairo orphans.dot -oorphans.png -Tcmapx: Warning: cell 
              +build | size too small for content
              +build |   . ERROR - dot -Tpng:cairo orphans.dot -oorphans.png -Tcmapx: in label of node 
              +build | refinery_schema_history
              +build |   . .....(0sec)
              +build |   . Writing/diagramming detailsINFO  - Completed summary in 0 seconds
              +build |   . INFO  - Writing/diagramming details
              +build |   . ERROR - dot -Tpng:cairo address.1degree.dot -oaddress.1degree.png -Tcmapx: 
              +build | Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo address.1degree.dot -oaddress.1degree.png -Tcmapx: 
              +build | Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo address.1degree.dot -oaddress.1degree.png -Tcmapx: 
              +build | Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo address.1degree.dot -oaddress.1degree.png -Tcmapx: 
              +build | in label of node address
              +build |   . ERROR - dot -Tpng:cairo address.1degree.dot -oaddress.1degree.png -Tcmapx: 
              +build | Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo address.1degree.dot -oaddress.1degree.png -Tcmapx: 
              +build | Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo address.1degree.dot -oaddress.1degree.png -Tcmapx: 
              +build | in label of node users
              +build |   . .ERROR - dot -Tpng:cairo users.1degree.dot -ousers.1degree.png -Tcmapx: 
              +build | Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo users.1degree.dot -ousers.1degree.png -Tcmapx: 
              +build | Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo users.1degree.dot -ousers.1degree.png -Tcmapx: in 
              +build | label of node address
              +build |   . ERROR - dot -Tpng:cairo users.1degree.dot -ousers.1degree.png -Tcmapx: 
              +build | Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo users.1degree.dot -ousers.1degree.png -Tcmapx: 
              +build | Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo users.1degree.dot -ousers.1degree.png -Tcmapx: 
              +build | Warning: cell size too small for content
              +build |   . ERROR - dot -Tpng:cairo users.1degree.dot -ousers.1degree.png -Tcmapx: in 
              +build | label of node users
              +build |   . .ERROR - dot -Tpng:cairo refinery_schema_history.1degree.dot 
              +build | -orefinery_schema_history.1degree.png -Tcmapx: Warning: cell size too small for 
              +build | content
              +build |   . ERROR - dot -Tpng:cairo refinery_schema_history.1degree.dot 
              +build | -orefinery_schema_history.1degree.png -Tcmapx: Warning: cell size too small for 
              +build | content
              +build |   . ERROR - dot -Tpng:cairo refinery_schema_history.1degree.dot 
              +build | -orefinery_schema_history.1degree.png -Tcmapx: Warning: cell size too small for 
              +build | content
              +build |   . ERROR - dot -Tpng:cairo refinery_schema_history.1degree.dot 
              +build | -orefinery_schema_history.1degree.png -Tcmapx: Warning: cell size too small for 
              +build | content
              +build |   . ERROR - dot -Tpng:cairo refinery_schema_history.1degree.dot 
              +build | -orefinery_schema_history.1degree.png -Tcmapx: Warning: cell size too small for 
              +build | content
              +build |   . ERROR - dot -Tpng:cairo refinery_schema_history.1degree.dot 
              +build | -orefinery_schema_history.1degree.png -Tcmapx: in label of node 
              +build | refinery_schema_history
              +build |   . .(0sec)
              +build |   . Wrote relationship details of 3 tables/views to directory 
              +build | 'docs/database_schema' in 0 seconds.
              +build |   . View the results by opening docs/database_schema/index.html
              +build |   . INFO  - Wrote table details in 0 seconds
              +build |   . INFO  - Wrote relationship details of 3 tables/views to directory 
              +build | 'docs/database_schema' in 0 seconds.
              +build |   . INFO  - View the results by opening docs/database_schema/index.html
```

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
