### PR TITLE
feat(rust): Bump `cargo-deny` to `0.18.9` version

### DIFF
--- a/earthly/rust/tools/Earthfile
+++ b/earthly/rust/tools/Earthfile
@@ -51,7 +51,7 @@ tool-refinery:
     DO +CARGO_BINSTALL --package=refinery_cli --version=0.8.16 --executable=refinery
 
 tool-cargo-deny:
-    DO +CARGO_BINSTALL --package=cargo-deny --version=0.18.0
+    DO +CARGO_BINSTALL --package=cargo-deny --version=0.18.9
 
 tool-cargo-modules:
     DO +CARGO_BINSTALL --package=cargo-modules --version=0.17.0 --test_param="--help"


### PR DESCRIPTION
# Description

Bumping `cargo-deny` to `0.18.9` version, fixing the following issue
```shell
       ./hermes+check *failed* |   $ cargo deny check --exclude-dev -W vulnerability -W unmaintained
  Error: /hermes+check *failed* |   > 2025-12-22 05:45:43 [ERROR] failed to load advisory database: parse error: 
        ./hermes+check *failed* | error parsing 
        ./hermes+check *failed* | /tmp/earthly/.cargo/advisory-dbs/advisory-db-3157b0e258782691/crates/cap-primiti
        ./hermes+check *failed* | ves/RUSTSEC-2024-0445.md: parse error: TOML parse error at line 8, column 8
        ./hermes+check *failed* |   .   |
        ./hermes+check *failed* |   . 8 | cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
        ./hermes+check *failed* |   .   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        ./hermes+check *failed* |   . unsupported CVSS version: 4.0
```

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
