### PR TITLE
chore(ci): Temporarily allow rustipfs fork

### DIFF
--- a/earthly/rust/stdcfgs/deny.toml
+++ b/earthly/rust/stdcfgs/deny.toml
@@ -69,6 +69,8 @@ allow-git = [
     "https://github.com/input-output-hk/catalyst_flutter_rust_bridge",
     # TODO: remove this when new version `0.6.2` would be published to crates.io
     "https://github.com/nervosnetwork/sparse-merkle-tree.git",
+    # TODO: remove this when change from forked is merged
+    "https://github.com/input-output-hk/rust-ipfs"    
 ]
 
 [licenses]

--- a/examples/rust/deny.toml
+++ b/examples/rust/deny.toml
@@ -69,6 +69,8 @@ allow-git = [
     "https://github.com/input-output-hk/catalyst_flutter_rust_bridge",
     # TODO: remove this when new version `0.6.2` would be published to crates.io
     "https://github.com/nervosnetwork/sparse-merkle-tree.git",
+    # TODO: remove this when change from forked is merged
+    "https://github.com/input-output-hk/rust-ipfs"    
 ]
 
 [licenses]


### PR DESCRIPTION
# Description

This CI changes the `deny.toml` to allow `rust-ipfs` fork.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-libs/pull/785

## Please confirm the following checks

* [X] My code follows the style guidelines of this project
* [X] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [X] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
